### PR TITLE
Quote CSV headers

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -72,7 +72,7 @@ var createColumnTitles = function(params, callback) {
     if (params.fieldNames) {
       str += JSON.stringify(element);
     } else {
-      str += element;
+      str += '"'+element+'"';
     }
   });
   callback(null, str);


### PR DESCRIPTION
You quote all the fields, but not the titles in the first row. The PR fixes that.
