### PR TITLE
Remove checkFields

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -18,7 +18,8 @@ module.exports = function(params, callback) {
     createColumnContent(params, title, function(csv) {
       callback(null, csv);
     });
-  };
+  });
+};
 
 /**
  * Create the title row with all the provided fields as column headings


### PR DESCRIPTION
I don't see a lot of value in validating that data exists when defined fields are missing. Instead, just make the field empty. I needed this functionality for my needs, and thought I'd share.

I appreciate if you don't want to merge this though. FWIW, if this module had a way to pass in options, observing checkFields would be a good candidate for an optional parameter.
