### PR TITLE
Add mapping functions for massaging individual fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,35 @@ Results in
 "Porsche", "green"
 ```
 
+### Example 5
 
+You can provide mapper functions to massage individual fields to be exported in a certain way.
+
+```javascript
+
+json2csv({data: json, fields: ['car', 'price'], 
+    mappers: {
+        price: function(price) {
+            return "$" + price;
+        }
+    }
+}, function(err,csv){
+    if(err) console.log(err);
+    console.log(csv);
+});
+
+```
+
+Results in
+
+```
+"car", "price"
+"Audi", "$10000"
+"BMW", "$15000"
+"Mercedes", "$20000"
+"Porsche", "$30000"
+
+```
 
 ## Command Line Interface
 

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -108,7 +108,11 @@ var createColumnContent = function(params, str, callback) {
       var eol = os.EOL || '\n';
       params.fields.forEach(function(field_element) {
         if (data_element.hasOwnProperty(field_element)) {
-          line += JSON.stringify(data_element[field_element]);
+          var current_data = data_element[field_element];
+          if(params.mappers && params.mappers.hasOwnProperty(field_element)) {
+            current_data = params.mappers[field_element](current_data);
+          }
+          line += JSON.stringify(current_data);
         }
         line += params.del;
       });

--- a/test/fixtures/out-mapper.csv
+++ b/test/fixtures/out-mapper.csv
@@ -1,0 +1,5 @@
+"carModel","price","color"
+"Audi","$10,000.00","blue"
+"BMW","$15,000.00","red"
+"Mercedes","$20,000.00","yellow"
+"Porsche","$30,000.00","green"

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,8 @@ var _in = require('./fixtures/in'),
   _out_selected = '',
   _out_reversed = '',
   _out_tsv = '',
-  _out_fieldNames = '';
+  _out_fieldNames = '',
+  _out_mapper = '';
 
 describe('json2csv', function() {
 
@@ -72,6 +73,13 @@ describe('json2csv', function() {
           fs.readFile('test/fixtures/out-fieldNames.csv', function(err, data) {
             if (err) callback(err);
             _out_fieldNames = data.toString();
+            callback(null);
+          });
+        },
+        function(callback) {
+          fs.readFile('test/fixtures/out-mapper.csv', function(err, data) {
+            if (err) callback(err);
+            _out_mapper = data.toString();
             callback(null);
           });
         }
@@ -191,6 +199,21 @@ describe('json2csv', function() {
       fieldNames: ['Car Model', 'Price USD']
     }, function(err, csv) {
       csv.should.equal(_out_fieldNames);
+      done();
+    })
+  })
+
+  it('should use mapper functions if provided', function(done){
+    json2csv({
+      data:_in,
+      fields: ['carModel', 'price', 'color'],
+      mappers: {
+        price: function(price){
+          return "$" + price.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,');
+        }
+      }
+    }, function(err,csv){
+      csv.should.equal(_out_mapper);      
       done();
     })
   })


### PR DESCRIPTION
It's often useful to massage certain fields in the json before exporting it to CSV. I added a `mappers` option to the `params` which allows field specific map functions to be provided. I've also included unit tests.
