### PR TITLE
Support default values when missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ or [use it from the CLI](https://github.com/zemirco/json2csv#command-line-interf
   - `fieldNames` Array of Strings, names for the fields at the same indexes.
     Must be the same length as `fields` array.
   - `del` - String, delimiter of columns. Defaults to `,` if not specified.
+  - `defaultValue` - String, default value to use when missing data. Defaults to `` if not specified.
   - `quotes` - String, quotes around cell values and column names. Defaults to `"` if not specified.
   - `nested` - Boolean, enables nested fields for getting JSON data. Defaults to `false` if not specified.
 - `callback` - **Required**; `function (error, csvString) {}`.

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -16,6 +16,7 @@ program
   .option('-f, --fields <fields>', 'Specify the fields to convert.')
   .option('-l, --fieldList [list]', 'Specify a file with a list of fields to include. One field per line.')
   .option('-d, --delimiter [delimiter]', 'Specify a delimiter other than the default comma to use.')
+  .option('-v, --defaultValue [defaultValue]', 'Specify a default value other than empty string.')
   .option('-e, --eol [value]', 'Specify an EOL value after each row.')
   .option('-q, --quote [value]', 'Specify an alternate quote value.')
   .option('-x, --nested', 'Allow fields to be nested via dot notation, e.g. \'car.make\'.')
@@ -101,6 +102,7 @@ getFields(function (err, fields) {
     opts.hasCSVColumnTitle = program.header;
     opts.quotes = program.quote;
     opts.nested = program.nested;
+    opts.defaultValue = program.defaultValue;
 
     if (program.delimiter) {
       opts.del = program.delimiter;

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -8,7 +8,8 @@ var get = require('lodash.get');
  * Main function that converts json to csv
  *
  * @param {Object} params Function parameters containing data, fields,
- * delimiter (default is ',') and hasCSVColumnTitle (default is true)
+ * delimiter (default is ','), hasCSVColumnTitle (default is true)
+ * and default value (default is '')
  * @param {Function} callback(err, csv) - Callback function
  *   if error, returning error in call back.
  *   if csv is created successfully, returning csv output to callback.
@@ -35,7 +36,7 @@ module.exports = function (params, callback) {
  * Check passing params
  *
  * @param {Object} params Function parameters containing data, fields,
- * delimiter, mark quotes and hasCSVColumnTitle
+ * delimiter, default value, mark quotes and hasCSVColumnTitle
  * @param {Function} callback Callback function returning error when invalid field is found
  */
 function checkParams(params, callback) {
@@ -69,6 +70,9 @@ function checkParams(params, callback) {
 
   //#check nested option
   params.nested = params.nested || false;
+
+  //#check default value
+  params.defaultValue = params.defaultValue;
 
   //#check hasCSVColumnTitle, if it is not explicitly set to false then true.
   if (params.hasCSVColumnTitle !== false) {
@@ -156,6 +160,9 @@ function createColumnContent(params, str) {
           }
 
           line += stringifiedElement;
+        } else if (params.defaultValue !== undefined) {
+          // Use default value if defined
+          line += JSON.stringify(params.defaultValue);
         }
 
         line += params.del;

--- a/test/fixtures/csv/defaultValue.csv
+++ b/test/fixtures/csv/defaultValue.csv
@@ -1,0 +1,5 @@
+"carModel","price"
+"Audi",0
+"BMW",15000
+"Mercedes","NULL"
+"Porsche",30000

--- a/test/fixtures/json/defaultValue.json
+++ b/test/fixtures/json/defaultValue.json
@@ -1,0 +1,6 @@
+[
+  { "carModel": "Audi",      "price": 0 },
+  { "carModel": "BMW",       "price": 15000 },
+  { "carModel": "Mercedes" },
+  { "carModel": "Porsche",   "price": 30000 }
+]

--- a/test/helpers/load-fixtures.js
+++ b/test/helpers/load-fixtures.js
@@ -14,7 +14,8 @@ var fixtures = [
   'eol',
   'fieldNames',
   'withSimpleQuotes',
-  'nested'
+  'nested',
+  'defaultValue'
 ];
 
 /*eslint-disable no-console*/

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var loadFixtures = require('./helpers/load-fixtures');
 var jsonDefault = require('./fixtures/json/default');
 var jsonQuotes = require('./fixtures/json/quotes');
 var jsonNested = require('./fixtures/json/nested');
+var jsonDefaultValue = require('./fixtures/json/defaultValue');
 var csvFixtures = {};
 
 async.parallel(loadFixtures(csvFixtures), function (err) {
@@ -216,6 +217,18 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.nested);
+      t.end();
+    });
+  });
+
+  test('should output default values when missing data', function (t) {
+    json2csv({
+      data: jsonDefaultValue,
+      fields: ['carModel', 'price'],
+      defaultValue: 'NULL'
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, csvFixtures.defaultValue);
       t.end();
     });
   });


### PR DESCRIPTION
Before only empty string was used.
Note: you need to specify the default value to use it so no backward compatibility issue.