### PR TITLE
Better EOL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ or [use it from the CLI](https://github.com/zemirco/json2csv#command-line-interf
   - `defaultValue` - String, default value to use when missing data. Defaults to `` if not specified.
   - `quotes` - String, quotes around cell values and column names. Defaults to `"` if not specified.
   - `nested` - Boolean, enables nested fields for getting JSON data. Defaults to `false` if not specified.
+  - `eol` - String, end-of-line marker. Defaults to the OS default.
 - `callback` - **Required**; `function (error, csvString) {}`.
 
 ### Example 1

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -141,7 +141,7 @@ function createColumnContent(params, str) {
     //if null or empty object do nothing
     if (dataElement && Object.getOwnPropertyNames(dataElement).length > 0) {
       var line = '';
-      var eol = os.EOL || '\n';
+      var eol = params.eol || os.EOL || '\n';
 
       params.fields.forEach(function (fieldElement) {
         var val;


### PR DESCRIPTION
The EOL string used for the header always used the OS default; I changed that to also use params.eol if present to avoid getting hybrid files.