### PR TITLE
Hotfix/validate params

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -49,7 +49,11 @@ function checkParams(params, callback) {
   }
 
   if (!params.fields && params.data && params.data.length) {
-    params.fields = Object.keys(params.data[0]);
+    if(typeof params.data[0] === 'object' && !Array.isArray(params.data[0]) && params.data[0] !== null){
+      params.fields = Object.keys(params.data[0]);
+    }else{
+      return callback(new Error('params should be a valid object.'));
+    }
   }
 
   //#check fieldNames

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -49,7 +49,7 @@ function checkParams(params, callback) {
   }
 
   if (!params.fields && params.data && params.data.length) {
-    if(typeof params.data[0] === 'object' && !Array.isArray(params.data[0]) && params.data[0] !== null){
+    if(typeof params.data[0] === 'object' && params.data[0] !== null){
       params.fields = Object.keys(params.data[0]);
     }else{
       return callback(new Error('params should be a valid object.'));


### PR DESCRIPTION
When `params` is not an object the module just crashes. This fix is intended to solve that and rise an error to the callback.

Sorry to throw this pull request to master but I don't see an updated branch to do it.