### PR TITLE
Hotfix/validate params

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -49,7 +49,11 @@ function checkParams(params, callback) {
   }
 
   if (!params.fields && params.data && params.data.length) {
-    params.fields = Object.keys(params.data[0]);
+    if(typeof params.data[0] === 'object' && !Array.isArray(params.data[0]) && params.data[0] !== null){
+      params.fields = Object.keys(params.data[0]);
+    }else{
+      return callback(new Error('params should be a valid object.'));
+    }
   }
 
   //#check fieldNames

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -49,7 +49,7 @@ function checkParams(params, callback) {
   }
 
   if (!params.fields && params.data && params.data.length) {
-    if(typeof params.data[0] === 'object' && !Array.isArray(params.data[0]) && params.data[0] !== null){
+    if(typeof params.data[0] === 'object' && params.data[0] !== null){
       params.fields = Object.keys(params.data[0]);
     }else{
       return callback(new Error('params should be a valid object.'));

--- a/test/index.js
+++ b/test/index.js
@@ -244,4 +244,16 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.end();
     });
   });
+
+  test('should error if params is not an object', function (t) {
+    json2csv({
+      data: 'none an object',
+      field: ['carModel'],
+      fieldNames: ['test', 'blah']
+    }, function (error, csv) {
+      t.equal(error.message, 'params should be a valid object.');
+      t.notOk(csv);
+      t.end();
+    });
+  });
 });


### PR DESCRIPTION
When `params` is not an object the module just crashes. This fix is intended to solve that and rise an error to the callback.

It has a test for the fix.

Sorry to throw this pull request to master but I don't see an updated branch to do it.