### PR TITLE
Ensure Node.js ver is above 0.12 to prevent issue with path.isAbsolute

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "test": "eslint . && node test | tap-spec",
     "test-coverage": "istanbul cover test/index.js --report lcovonly | tap-spec"
   },
+  "engines": {
+    "node": ">=0.12"
+  },
   "dependencies": {
     "cli-table": "^0.3.1",
     "commander": "^2.8.1",


### PR DESCRIPTION
This caught me out on Node.js versions below 0.12.x. Since _path.isAbsolute_ is not present until v0.12.0 this check will ensure it fails to install on those versions.