### PR TITLE
Add failing test to illustrate problem with defaultValue of an empty string

### DIFF
--- a/test/fixtures/csv/defaultValueEmpty.csv
+++ b/test/fixtures/csv/defaultValueEmpty.csv
@@ -1,0 +1,5 @@
+"carModel","price"
+"Audi",0
+"BMW",15000
+"Mercedes",""
+"Porsche",30000

--- a/test/fixtures/json/defaultValueEmpty.json
+++ b/test/fixtures/json/defaultValueEmpty.json
@@ -1,0 +1,6 @@
+[
+  { "carModel": "Audi",      "price": 0 },
+  { "carModel": "BMW",       "price": 15000 },
+  { "carModel": "Mercedes",  "price": null },
+  { "carModel": "Porsche",   "price": 30000 }
+]

--- a/test/helpers/load-fixtures.js
+++ b/test/helpers/load-fixtures.js
@@ -17,6 +17,7 @@ var fixtures = [
   'withSimpleQuotes',
   'nested',
   'defaultValue',
+  'defaultValueEmpty',
   'embeddedjson',
   'fancyfields',
   'trailingBackslash'

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ var jsonDefault = require('./fixtures/json/default');
 var jsonQuotes = require('./fixtures/json/quotes');
 var jsonNested = require('./fixtures/json/nested');
 var jsonDefaultValue = require('./fixtures/json/defaultValue');
+var jsonDefaultValueEmpty = require('./fixtures/json/defaultValueEmpty');
 var jsonTrailingBackslash = require('./fixtures/json/trailingBackslash');
 var csvFixtures = {};
 
@@ -242,6 +243,18 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.defaultValue);
+      t.end();
+    });
+  });
+
+  test('should output default values when default value is set to empty string', function (t) {
+    json2csv({
+      data: jsonDefaultValueEmpty,
+      fields: ['carModel', 'price'],
+      defaultValue: ''
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, csvFixtures.defaultValueEmpty);
       t.end();
     });
   });


### PR DESCRIPTION
The problem only manifests when the JSON object has a field that is null (not undefined), and the option 'defaultValue' is set to an empty string.