### PR TITLE
Support excel strings

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -181,10 +181,10 @@ function createColumnContent(params, str) {
           //JSON.stringify('\\') results in a string with two backslash
           //characters in it. I.e. '\\\\'.
           stringifiedElement = stringifiedElement.replace(/\\\\/g, '\\');
-
-         if (params.excelStrings) {
-           stringifiedElement = '"="' + stringifiedElement + '""';
-         }
+          
+          if (params.excelStrings && typeof val === 'string') {
+            stringifiedElement = '"="' + stringifiedElement + '""';
+          }
 
           line += stringifiedElement;
         }

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -182,6 +182,10 @@ function createColumnContent(params, str) {
           //characters in it. I.e. '\\\\'.
           stringifiedElement = stringifiedElement.replace(/\\\\/g, '\\');
 
+         if (params.excelStrings) {
+           stringifiedElement = '"="' + stringifiedElement + '""';
+         }
+
           line += stringifiedElement;
         }
 

--- a/test/fixtures/csv/excelStrings.csv
+++ b/test/fixtures/csv/excelStrings.csv
@@ -1,0 +1,5 @@
+"carModel","price","color"
+"=""Audi""",0,"=""blue"""
+"=""BMW""",15000,"=""red"""
+"=""Mercedes""",20000,"=""yellow"""
+"=""Porsche""",30000,"=""green"""

--- a/test/helpers/load-fixtures.js
+++ b/test/helpers/load-fixtures.js
@@ -21,7 +21,8 @@ var fixtures = [
   'embeddedjson',
   'flattenedEmbeddedJson',
   'fancyfields',
-  'trailingBackslash'
+  'trailingBackslash',
+  'excelStrings'
 ];
 
 /*eslint-disable no-console*/

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ var jsonNested = require('./fixtures/json/nested');
 var jsonDefaultValue = require('./fixtures/json/defaultValue');
 var jsonDefaultValueEmpty = require('./fixtures/json/defaultValueEmpty');
 var jsonTrailingBackslash = require('./fixtures/json/trailingBackslash');
+var console = require('console');
 var csvFixtures = {};
 
 async.parallel(loadFixtures(csvFixtures), function (err) {
@@ -51,6 +52,7 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.end();
     });
   });
+  
 
   test('should parse json to csv without fields', function (t) {
     json2csv({
@@ -362,12 +364,24 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     });
   });
   
-  test('should escape " when preceeded by \\', function(t){
+  test('should escape " when preceeded by \\', function (t){
     json2csv({
       data: [{field: '\\"'}]
-    }, function(error, csv){
+    }, function (error, csv){
       t.error(error);
       t.equal(csv, '"field"\n"\\""');
+      t.end();
+    });
+  });
+  
+  test('should format strings to force excel to view the values as strings', function (t) {
+    json2csv({
+      data: jsonDefault,
+      excelStrings:true,
+      fields: ['carModel', 'price', 'color']
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, csvFixtures.excelStrings);
       t.end();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,6 @@ var jsonNested = require('./fixtures/json/nested');
 var jsonDefaultValue = require('./fixtures/json/defaultValue');
 var jsonDefaultValueEmpty = require('./fixtures/json/defaultValueEmpty');
 var jsonTrailingBackslash = require('./fixtures/json/trailingBackslash');
-var console = require('console');
 var csvFixtures = {};
 
 async.parallel(loadFixtures(csvFixtures), function (err) {


### PR DESCRIPTION
Excel auto formats csv files containing large numbers into scientific notation when opened directly.  This makes it difficult for things such as serial numbers and asset tags to open in excel correctly.  

This proposal makes it so the user can pass in the option `{excelStrings:true}`, and it will force all fields to be formatted in such a way that excel interprets it as a string, like so: `"=""Data Here"""`. More information can be found here: http://superuser.com/questions/318420/formatting-a-comma-delimited-csv-to-force-excel-to-interpret-value-as-a-string