### PR TITLE
Fix/newlines in cells

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -181,7 +181,10 @@ function createColumnContent(params, str) {
           //JSON.stringify('\\') results in a string with two backslash
           //characters in it. I.e. '\\\\'.
           stringifiedElement = stringifiedElement.replace(/\\\\/g, '\\');
-          
+
+          // preserve newlines
+          stringifiedElement = stringifiedElement.split('\\n').join('\n')
+
           if (params.excelStrings && typeof val === 'string') {
             stringifiedElement = '"="' + stringifiedElement + '""';
           }

--- a/test/fixtures/csv/newLineCellContent.csv
+++ b/test/fixtures/csv/newLineCellContent.csv
@@ -1,0 +1,7 @@
+"carModel","price","color"
+"Aud
+i",0,"blue"
+"BMW",15000,"red"
+"Me
+rcedes",20000,"yellow"
+"Porsche",30000,"green"

--- a/test/fixtures/json/newlines.json
+++ b/test/fixtures/json/newlines.json
@@ -1,0 +1,6 @@
+[
+  { "carModel": "Aud\ni",      "price": 0,  "color": "blue" },
+  { "carModel": "BMW",       "price": 15000,  "color": "red" },
+  { "carModel": "Me\nrcedes",  "price": 20000,  "color": "yellow" },
+  { "carModel": "Porsche",   "price": 30000,  "color": "green" }
+]

--- a/test/helpers/load-fixtures.js
+++ b/test/helpers/load-fixtures.js
@@ -22,7 +22,8 @@ var fixtures = [
   'flattenedEmbeddedJson',
   'fancyfields',
   'trailingBackslash',
-  'excelStrings'
+  'excelStrings',
+  'newLineCellContent'
 ];
 
 /*eslint-disable no-console*/

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ var jsonNested = require('./fixtures/json/nested');
 var jsonDefaultValue = require('./fixtures/json/defaultValue');
 var jsonDefaultValueEmpty = require('./fixtures/json/defaultValueEmpty');
 var jsonTrailingBackslash = require('./fixtures/json/trailingBackslash');
+var jsonNewlines = require('./fixtures/json/newlines');
 var csvFixtures = {};
 
 async.parallel(loadFixtures(csvFixtures), function (err) {
@@ -51,7 +52,7 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.end();
     });
   });
-  
+
 
   test('should parse json to csv without fields', function (t) {
     json2csv({
@@ -362,7 +363,7 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.end();
     });
   });
-  
+
   test('should escape " when preceeded by \\', function (t){
     json2csv({
       data: [{field: '\\"'}]
@@ -372,7 +373,7 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.end();
     });
   });
-  
+
   test('should format strings to force excel to view the values as strings', function (t) {
     json2csv({
       data: jsonDefault,
@@ -381,6 +382,16 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.excelStrings);
+      t.end();
+    });
+  });
+
+  test('should preserve newlines within cell content', function (t) {
+    json2csv({
+      data: jsonNewlines
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, csvFixtures.newLineCellContent);
       t.end();
     });
   });


### PR DESCRIPTION
**Issue:** Newlines are not preserved within a cell's content.
**Cause:** JSON.stringify escapes `\n` and you end up `\\n` instead.
**Fix:** Replace occurrences of `\\n` with `\n` in the `stringifiedElement` (before the row delimiter).

*Includes appropriate tests*