### PR TITLE
Fix default value #117 and #118

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -157,21 +157,20 @@ function createColumnContent(params, str) {
 
       params.fields.forEach(function (fieldElement) {
         var val;
+        var defaultValue = params.defaultValue;
+        if (typeof fieldElement === 'object' && 'default' in fieldElement) {
+          defaultValue = fieldElement.default;
+        }
 
         if (fieldElement && (typeof fieldElement === 'string' || typeof fieldElement.value === 'string')) {
           var path = (typeof fieldElement === 'string') ? fieldElement : fieldElement.value;
-
-          var defaultValue = params.defaultValue;
-          if (typeof fieldElement === 'object' && 'default' in fieldElement) {
-            defaultValue = fieldElement.default;
-          }
-
           val = lodashGet(dataElement, path, defaultValue);
-          if (val === null && defaultValue !== undefined){
-            val = defaultValue;
-          }
         } else if (fieldElement && typeof fieldElement.value === 'function') {
-          val = fieldElement.value(dataElement) || fieldElement.default;
+          val = fieldElement.value(dataElement);
+        }
+
+        if (val === null || val === undefined){
+          val = defaultValue;
         }
 
         if (val !== undefined) {

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -160,7 +160,12 @@ function createColumnContent(params, str) {
 
         if (fieldElement && (typeof fieldElement === 'string' || typeof fieldElement.value === 'string')) {
           var path = (typeof fieldElement === 'string') ? fieldElement : fieldElement.value;
-          var defaultValue = fieldElement.default || params.defaultValue;
+
+          var defaultValue = params.defaultValue;
+          if (typeof fieldElement === 'object' && 'default' in fieldElement) {
+            defaultValue = fieldElement.default;
+          }
+
           val = lodashGet(dataElement, path, defaultValue);
           if (val === null && defaultValue !== undefined){
             val = defaultValue;

--- a/test/fixtures/csv/overriddenDefaultValue.csv
+++ b/test/fixtures/csv/overriddenDefaultValue.csv
@@ -1,0 +1,5 @@
+"carModel","price","color"
+"Audi",0,"blue"
+"BMW",1,"red"
+"Mercedes",20000,""
+"Porsche",30000,"green"

--- a/test/fixtures/json/overridenDefaultValue.json
+++ b/test/fixtures/json/overridenDefaultValue.json
@@ -1,0 +1,6 @@
+[
+  { "carModel": "Audi",      "price": 0,      "color": "blue"   },
+  { "carModel": "BMW",                        "color": "red"    },
+  { "carModel": "Mercedes",  "price": 20000                     },
+  { "carModel": "Porsche",   "price": 30000,  "color": "green"  }
+]

--- a/test/helpers/load-fixtures.js
+++ b/test/helpers/load-fixtures.js
@@ -23,7 +23,8 @@ var fixtures = [
   'fancyfields',
   'trailingBackslash',
   'excelStrings',
-  'newLineCellContent'
+  'newLineCellContent',
+  'overriddenDefaultValue',
 ];
 
 /*eslint-disable no-console*/

--- a/test/index.js
+++ b/test/index.js
@@ -419,4 +419,33 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.end();
     });
   });
+
+  test('should use options.defaultValue when using function with no field.default', function (t) {
+    json2csv({
+      data: jsonOverriddenDefaultValue,
+      fields: [
+        {
+          value: 'carModel',
+        },
+        {
+          label: 'price',
+          value: function (row) {
+            return row.price;
+          },
+          default: 1
+        },
+        {
+          label: 'color',
+          value: function (row) {
+            return row.color;
+          },
+        }
+      ],
+      defaultValue: ''
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, csvFixtures.overriddenDefaultValue);
+      t.end();
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ var jsonDefaultValue = require('./fixtures/json/defaultValue');
 var jsonDefaultValueEmpty = require('./fixtures/json/defaultValueEmpty');
 var jsonTrailingBackslash = require('./fixtures/json/trailingBackslash');
 var jsonNewlines = require('./fixtures/json/newlines');
+var jsonOverriddenDefaultValue = require('./fixtures/json/overridenDefaultValue');
 var csvFixtures = {};
 
 async.parallel(loadFixtures(csvFixtures), function (err) {
@@ -392,6 +393,29 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.newLineCellContent);
+      t.end();
+    });
+  });
+
+  test('should override defaultValue with field.defaultValue', function (t) {
+    json2csv({
+      data: jsonOverriddenDefaultValue,
+      fields: [
+        {
+          value: 'carModel',
+        },
+        {
+          value: 'price',
+          default: 1
+        },
+        {
+          value: 'color',
+        }
+      ],
+      defaultValue: ''
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, csvFixtures.overriddenDefaultValue);
       t.end();
     });
   });


### PR DESCRIPTION
Here is my proposition of fix for #117 and #118.

2 remarks:
* I used `typeof fieldElement === 'object' && 'default' in fieldElement` which might be clearer if using `_.has(fieldElement, 'default')` but I didn't want to impose lodash
* Default value is used if value is null or undefined, I don't know if it is your expected behaviour