### PR TITLE
Add support for appending CSV data to an existing CSV file

### DIFF
--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var Converter = require("csvtojson").Converter;
+var csvtojson = new Converter({});
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
@@ -126,16 +128,48 @@ getFields(function (err, fields) {
       opts.newLine = program.newLine;
     }
 
-    var csv = json2csv(opts);
     if (program.output) {
-      fs.writeFile(program.output, csv, function (writeError) {
-        if (writeError) {
-          throw new Error('Cannot save to ' + program.output + ': ' + writeError);
-        }
+      // Check for existing file.
+      fs.readFile(program.output, 'utf-8', function (err, file) {
+        if (!err) {
+          //console.log("FILE EXISTS")
+          //console.log(file)
+          csvtojson.fromString(file, function(err, additionalJSON) {
+            //console.log("THE opts")
+            //console.log(opts)
+            //console.log("additionalJSON")
+            //console.log(additionalJSON)
+            //console.log(typeof additionalJSON)
+            additionalJSON.forEach(function(item) {
+              opts.data.push(item)
+            })
+            //console.log("NEW opts")
+            //console.log(opts)
+            var csv = json2csv(opts);
+            fs.writeFile(program.output, csv, function (writeError) {
+              if (writeError) {
+                throw new Error('Cannot save to ' + program.output + ': ' + writeError);
+              }
 
-        debug(program.input + ' successfully converted to ' + program.output);
-      });
+              debug(program.input + ' successfully converted to ' + program.output);
+            })
+          })
+        } else {
+          //console.log("FILE DOES NOT EXIST")
+          var csv = json2csv(opts);
+          fs.writeFile(program.output, csv, function (writeError) {
+            if (writeError) {
+              throw new Error('Cannot save to ' + program.output + ': ' + writeError);
+            }
+
+            debug(program.input + ' successfully converted to ' + program.output);
+          })
+        }
+      })
+
+
     } else {
+      var csv = json2csv(opts);
       /*eslint-disable no-console */
       if (program.pretty) {
         console.log(logPretty(csv));

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "cli-table": "^0.3.1",
     "commander": "^2.8.1",
+    "csvtojson": "^1.0.0",
     "debug": "^2.2.0",
     "flat": "^2.0.0",
     "lodash.flatten": "^4.2.0",


### PR DESCRIPTION
At the moment, every time I send data to a CSV, the CSV is overwritten.
```
$ echo '[{"a":1,"b":2}, {"a":3,"b":4}]' | json2csv -o foo.csv
$ cat foo.csv
"a","b"
1,2
3,4
$ echo '[{"a":1,"b":2}, {"a":3,"b":4}]' | json2csv -o foo.csv
$ cat foo.csv
"a","b"
1,2
3,4
```

But I would like for the command to check for the file's existence and append to it so we would get...

```
$ echo '[{"a":1,"b":2}, {"a":3,"b":4}]' | json2csv -o foo.csv
$ cat foo.csv
"a","b"
1,2
3,4
$ echo '[{"a":1,"b":2}, {"a":3,"b":4}]' | json2csv -o foo.csv
$ cat foo.csv
"a","b"
1,2
3,4
1,2
3,4
```

