### PR TITLE
Remove debugger statement

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -79,7 +79,6 @@ function checkParams(params) {
 
     dataFields = lodashFlatten(dataFields);
     params.fields = lodashUniq(dataFields);
-    debugger;
   }
 
 


### PR DESCRIPTION
A `debugger` statement has been left in the current release of this library. This makes it difficult to use this library and debug a frontend app effectively. 