### PR TITLE
Handle EPIPE to avoid crash when piped to other process (like `head`).

### DIFF
--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -136,6 +136,13 @@ getFields(function (err, fields) {
         debug(program.input + ' successfully converted to ' + program.output);
       });
     } else {
+      // don't fail if piped to e.g. head
+      process.stdout.on('error', function (error) {
+        if (error.code === 'EPIPE') {
+          process.exit();
+        }
+      })
+
       /*eslint-disable no-console */
       if (program.pretty) {
         console.log(logPretty(csv));


### PR DESCRIPTION
Without this patch, json2csv will crash when it receives EPIPE from the process it's piped into.

```console
$ cat big.json | json2csv | head -10
//...csv data...
events.js:154
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at exports._errnoException (util.js:856:11)
    at WriteWrap.afterWrite (net.js:763:14)

```