### PR TITLE
Webpack UMD build available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 server.*
 published
 *.log
+dist

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install
 $ npm install json2csv --save
 ```
 
-Include the module and run or [use it from the Command Line](https://github.com/zemirco/json2csv#command-line-interface).
+Include the module and run or [use it from the Command Line](https://github.com/zemirco/json2csv#command-line-interface). It's also possible to include `json2csv` as a global using an HTML script tag, though it's normally recommended that modules are used.
 
 ```javascript
 var json2csv = require('json2csv');
@@ -385,6 +385,23 @@ $ json2csv -i test.json -f name,version > test.csv
 # Append additional rows
 $ json2csv -i test.json -f name,version --no-header >> test.csv
 ```
+
+## Include using a script tag (not recommended)
+
+If it's not possible to work with node modules, `json2csv` can be declared as a global by requesting `dist/json2csv.js` via an HTML script tag:
+
+```
+<script src="node_modules/json2csv/dist/json2csv.js"></script>
+<script>
+  console.log(typeof json2csv === 'function'); // true
+</script>
+```
+
+### Building
+
+When developing, it's necessary to run `webpack` to prepare the built script. This can be done easily with `npm build`.
+
+If `webpack` is not already available from the command line, use `npm install -g webpack`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ If it's not possible to work with node modules, `json2csv` can be declared as a 
 
 ### Building
 
-When developing, it's necessary to run `webpack` to prepare the built script. This can be done easily with `npm build`.
+When developing, it's necessary to run `webpack` to prepare the built script. This can be done easily with `npm run build`.
 
 If `webpack` is not already available from the command line, use `npm install -g webpack`.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/zemirco/json2csv"
   },
   "scripts": {
+    "build": "webpack",
     "test": "eslint . && node test | tap-spec",
     "test-coverage": "istanbul cover test/index.js --report lcovonly | tap-spec"
   },
@@ -44,6 +45,7 @@
     "eslint": "^2.12.0",
     "istanbul": "^0.4.3",
     "tap-spec": "^4.1.0",
-    "tape": "^4.0.0"
+    "tape": "^4.0.0",
+    "webpack": "^1.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "scripts": {
     "build": "webpack",
+    "prepublish": "npm run build",
     "test": "eslint . && node test | tap-spec",
     "test-coverage": "istanbul cover test/index.js --report lcovonly | tap-spec"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,16 @@
+var webpack = require('webpack');
+
+var webpackConfig = {
+  entry: './lib/json2csv.js',
+  resolve: {
+    extensions: ['', '.js']
+  },
+  output: {
+    path: __dirname + '/dist',
+    libraryTarget: 'umd',
+    library: 'json2csv',
+    filename: 'json2csv.js'
+  }
+};
+
+module.exports = webpackConfig;


### PR DESCRIPTION
This change adds a webpack build configuration which will create a UMD module of json2csv in the `dist/` directory. It's ignored by git, but isn't ignored by npm, so it will be available when downloaded via npm.

I've updated the README as well.

Now `dist/json2csv.js` can be included with an HTML script tag, if the user is unable to work with javascript modules. All dependencies are included. I don't like this that much, but I'm in a situation where adding webpack or another module packer to the project I'm working on would mean a ton of refactoring. And no other JSON -> CSV String package I've found (that isn't module-only) will let me specify a field order.

**NOTE:** If this is going to be distributed via npm, it's important that `npm run build` is run before every release, or `dist/json2csv.js` will be unavailable or out-of-date.