### PR TITLE
The document for double quote escape is misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ try {
   - `del` - String, delimiter of columns. Defaults to `,` if not specified.
   - `defaultValue` - String, default value to use when missing data. Defaults to `<empty>` if not specified. (Overridden by `fields[].default`)
   - `quotes` - String, quotes around cell values and column names. Defaults to `"` if not specified.
-  - `doubleQuotes` - String, the value to replace double quotes in strings. Defaults to 3x`quotes` (for example `"""`) if not specified.
+  - `doubleQuotes` - String, the value to replace double quotes in strings. Defaults to 2x`quotes` (for example `""`) if not specified.
   - `hasCSVColumnTitle` - Boolean, determines whether or not CSV file will contain a title column. Defaults to `true` if not specified.
   - `eol` - String, it gets added to each row of data. Defaults to `` if not specified.
   - `newLine` - String, overrides the default OS line ending (i.e. `\n` on Unix and `\r\n` on Windows).

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -19,7 +19,7 @@ var flatten = require('flat');
  * @property {String} [del=","] - delimiter of columns
  * @property {String} [defaultValue="<empty>"] - default value to use when missing data
  * @property {String} [quotes='"'] - quotes around cell values and column names
- * @property {String} [doubleQuotes='"""'] - the value to replace double quotes in strings
+ * @property {String} [doubleQuotes='""'] - the value to replace double quotes in strings
  * @property {Boolean} [hasCSVColumnTitle=true] - determines whether or not CSV file will contain a title column
  * @property {String} [eol=''] - it gets added to each row of data
  * @property {String} [newLine] - overrides the default OS line ending (\n on Unix \r\n on Windows)


### PR DESCRIPTION
From the documentation, the default behaviour to escape the double quote is:
```
doubleQuotes - String, the value to replace double quotes in strings. Defaults to 3xquotes (for example """) if not specified.
```

But in fact, it is replaced with 2xquotes, which means " => "". The behaviour is **CORRECT**, but the documentation is wrong.

Array(3).join(quote) generates 2xquote.
