### PR TITLE
Remove last delimiter by its length

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -246,8 +246,8 @@ function createColumnContent(params, str) {
         line += params.del;
       });
 
-      //remove last delimeter
-      line = line.substring(0, line.length - 1);
+      //remove last delimeter by its length
+      line = line.substring(0, line.length - params.del.length);
       //Replace single quotes with double quotes. Single quotes are preceeded by
       //a backslash. Be careful not to remove backslash content from the string.
       line = line.split('\\\\').map(function (portion) {
@@ -273,13 +273,13 @@ function createColumnContent(params, str) {
  */
 function createDataRows(params) {
   var dataRows = params.data;
-  
+
   if (params.unwindPath) {
     dataRows = [];
     params.data.forEach(function(dataEl) {
       var unwindArray = lodashGet(dataEl, params.unwindPath);
       var isArr = Array.isArray(unwindArray);
-      
+
       if (isArr && unwindArray.length) {
         unwindArray.forEach(function(unwindEl) {
           var dataCopy = lodashCloneDeep(dataEl);
@@ -295,6 +295,6 @@ function createDataRows(params) {
       }
     });
   }
-  
+
   return dataRows;
 }

--- a/test/fixtures/csv/delimiter.csv
+++ b/test/fixtures/csv/delimiter.csv
@@ -1,0 +1,3 @@
+"firstname"|@|"lastname"|@|"email"
+"foo"|@|"bar"|@|"foo.bar@json2csv.com"
+"bar"|@|"foo"|@|"bar.foo@json2csv.com"

--- a/test/helpers/load-fixtures.js
+++ b/test/helpers/load-fixtures.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var fixtures = [
   'default',
+  'delimiter',
   'withoutTitle',
   'withoutQuotes',
   'withNotExistField',

--- a/test/index.js
+++ b/test/index.js
@@ -44,6 +44,19 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     releasedZalgo = false;
   });
 
+  test('should work asynchronously and remove last delimiter |@|', function (t) {
+    json2csv({
+      data: [
+        { firstname: 'foo', lastname: 'bar', email: 'foo.bar@json2csv.com' },
+        { firstname: 'bar', lastname: 'foo', email: 'bar.foo@json2csv.com' }
+      ],
+      del: '|@|'
+    }, function (err, csv) {
+      t.equal(csv, csvFixtures.delimiter);
+      t.end();
+    });
+  });
+
   test('should error synchronously if fieldNames don\'t line up to fields', function (t) {
     var csv;
     try {


### PR DESCRIPTION
First of all,  thanks for you're awesome module you did a great job :+1: 

This is a quick fix for an issue we had.
The idea is when we set the `del: '|@|'` param to a string with length greater than 1, lines will end up with part of the delimiter (without its last char), but it shouldn't add it at all.
 