### PR TITLE
Preserve new lines in cells with option preserveNewLinesInCells (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ try {
 - Supports optional custom quotation marks
 - Not create CSV column title by passing hasCSVColumnTitle: false, into params.
 - If field is not exist in object then the field value in CSV will be empty.
-- Preserve new lines in cells. Should be used we \r\n line ending for full compatibility with Excel.
+- Preserve new lines in values. Should be used with \r\n line endings for full compatibility with Excel.
 
 ## Use as a module
 
@@ -68,7 +68,7 @@ try {
   - `unwindPath` - String, creates multiple rows from a single JSON document similar to MongoDB's $unwind
   - `excelStrings` - Boolean, converts string data into normalized Excel style data.
   - `includeEmptyRows` - Boolean, includes empty rows. Defaults to `false`.
-  - `preserveNewLinesInCells` - Boolean, preserve \r and \n in cells. Defaults to `false`.
+  - `preserveNewLinesInValues` - Boolean, preserve \r and \n in values. Defaults to `false`.
 - `callback` - `function (error, csvString) {}`. If provided, will callback asynchronously. Only supported for compatibility reasons.
 
 #### Example `fields` option

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ try {
 - Supports optional custom quotation marks
 - Not create CSV column title by passing hasCSVColumnTitle: false, into params.
 - If field is not exist in object then the field value in CSV will be empty.
+- Preserve new lines in cells. Should be used we \r\n line ending for full compatibility with Excel.
 
 ## Use as a module
 
@@ -67,6 +68,7 @@ try {
   - `unwindPath` - String, creates multiple rows from a single JSON document similar to MongoDB's $unwind
   - `excelStrings` - Boolean, converts string data into normalized Excel style data.
   - `includeEmptyRows` - Boolean, includes empty rows. Defaults to `false`.
+  - `preserveNewLinesInCells` - Boolean, preserve \r and \n in cells. Defaults to `false`.
 - `callback` - `function (error, csvString) {}`. If provided, will callback asynchronously. Only supported for compatibility reasons.
 
 #### Example `fields` option

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -224,7 +224,19 @@ function createColumnContent(params, str) {
         }
 
         if (val !== undefined) {
+          if (params.preserveNewLinesInCells && typeof val === 'string') {
+            val = val
+              .replace(/\n/g, '\u2028')
+              .replace(/\r/g, '\u2029');
+          }
+
           var stringifiedElement = JSON.stringify(val);
+
+          if (params.preserveNewLinesInCells && typeof val === 'string') {
+            stringifiedElement = stringifiedElement
+              .replace(/\u2028/g, '\n')
+              .replace(/\u2029/g, '\r');
+          }
 
           if (typeof val === 'object') stringifiedElement = JSON.stringify(stringifiedElement);
 

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -224,7 +224,7 @@ function createColumnContent(params, str) {
         }
 
         if (val !== undefined) {
-          if (params.preserveNewLinesInCells && typeof val === 'string') {
+          if (params.preserveNewLinesInValues && typeof val === 'string') {
             val = val
               .replace(/\n/g, '\u2028')
               .replace(/\r/g, '\u2029');
@@ -232,7 +232,7 @@ function createColumnContent(params, str) {
 
           var stringifiedElement = JSON.stringify(val);
 
-          if (params.preserveNewLinesInCells && typeof val === 'string') {
+          if (params.preserveNewLinesInValues && typeof val === 'string') {
             stringifiedElement = stringifiedElement
               .replace(/\u2028/g, '\n')
               .replace(/\u2029/g, '\r');

--- a/test/fixtures/json/newLine.json
+++ b/test/fixtures/json/newLine.json
@@ -1,0 +1,4 @@
+[
+  {"a string": "with a \u2028description\\n and\na new line"},
+  {"a string": "with a \u2029\u2028description and\r\nanother new line"}
+]

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ var jsonTrailingBackslash = require('./fixtures/json/trailingBackslash');
 var jsonOverriddenDefaultValue = require('./fixtures/json/overridenDefaultValue');
 var jsonEmptyRow = require('./fixtures/json/emptyRow');
 var jsonUnwind = require('./fixtures/json/unwind');
+var jsonNewLine = require('./fixtures/json/newLine');
 var csvFixtures = {};
 
 async.parallel(loadFixtures(csvFixtures), function (err) {
@@ -615,5 +616,38 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
       t.equal(csv, csvFixtures.unwind);
       t.end()
     })
+  });
+
+  test('should not preserve new lines in cells by default', function(t) {
+    json2csv({
+      data: jsonNewLine,
+      fields: ['a string'],
+      newLine: '\r\n',
+    }, function(error, csv) {
+      t.error(error);
+      t.equal(csv, [
+        '"a string"',
+        '"with a \u2028description\\n and\\na new line"',
+        '"with a \u2029\u2028description and\\r\\nanother new line"'
+      ].join('\r\n'));
+      t.end();
+    });
+  });
+
+  test('should preserve new lines in cells when options.preserveNewLinesInCell is true', function(t) {
+    json2csv({
+      data: jsonNewLine,
+      fields: ['a string'],
+      newLine: '\r\n',
+      preserveNewLinesInCells: true,
+    }, function(error, csv) {
+      t.error(error);
+      t.equal(csv, [
+        '"a string"',
+        '"with a \ndescription\\n and\na new line"',
+        '"with a \r\ndescription and\r\nanother new line"'
+      ].join('\r\n'));
+      t.end();
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -618,7 +618,7 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     })
   });
 
-  test('should not preserve new lines in cells by default', function(t) {
+  test('should not preserve new lines in values by default', function(t) {
     json2csv({
       data: jsonNewLine,
       fields: ['a string'],
@@ -634,12 +634,12 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     });
   });
 
-  test('should preserve new lines in cells when options.preserveNewLinesInCell is true', function(t) {
+  test('should preserve new lines in values when options.preserveNewLinesInValues is true', function(t) {
     json2csv({
       data: jsonNewLine,
       fields: ['a string'],
       newLine: '\r\n',
-      preserveNewLinesInCells: true,
+      preserveNewLinesInValues: true,
     }, function(error, csv) {
       t.error(error);
       t.equal(csv, [


### PR DESCRIPTION
\n and \r are converted to \u2028 and \u2029 in order to pass through
JSON.stringify, then converted back to \n and \r.
Note any original \u2028 and \u2029 are converted to \n and \r.