### PR TITLE
fix(cli): pass BOM cli option to function

### DIFF
--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -114,7 +114,7 @@ getFields(function (err, fields) {
       defaultValue: program.defaultValue,
       flatten: program.flatten,
       includeEmptyRows: program.includeEmptyRows,
-      withBOM: program.withBOM
+      withBOM: program.withBom
     };
 
     if (program.delimiter) {


### PR DESCRIPTION
+ program.withBom is where commander stores the --with-bom option, instead of withBOM, which is the functions internal representation of this option.