### PR TITLE
typedef: add missing options, fix type of `unwindPath`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,9 +28,11 @@ declare namespace json2csv {
     eol?: string;
     newLine?: string;
     flatten?: boolean;
-    unwindPath?: string;
+    unwindPath?: string | string[];
     excelStrings?: boolean;
     includeEmptyRows?: boolean;
+    preserveNewLinesInValues?: boolean;
+    withBOM?: boolean;
   }
 
   interface Callback {


### PR DESCRIPTION
Two documented options were missing from the typedef:
- `preserveNewLinesInValues`
- `withBOM`

Documentation show `unwindPath` can be a string or an array of strings, typedef allowed only single string.