### PR TITLE
Fix header flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ try {
 - Supports optional custom delimiters
 - Supports optional custom eol value
 - Supports optional custom quotation marks
-- Not create CSV column title by passing noHeader: false, into params.
+- Not create CSV column title by passing header: false, into params.
 - If field is not exist in object then the field value in CSV will be empty.
 - Preserve new lines in values. Should be used with \r\n line endings for full compatibility with Excel.
 - Add a BOM character at the beginning of the csv to make Excel displaying special characters correctly.
@@ -64,7 +64,7 @@ try {
   - `defaultValue` - String, default value to use when missing data. Defaults to `<empty>` if not specified. (Overridden by `fields[].default`)
   - `quote` - String, quote around cell values and column names. Defaults to `"` if not specified.
   - `doubleQuote` - String, the value to replace double quote in strings. Defaults to 2x`quotes` (for example `""`) if not specified.
-  - `noHeader` - Boolean, determines whether or not CSV file will contain a title column. Defaults to `true` if not specified.
+  - `header` - Boolean, determines whether or not CSV file will contain a title column. Defaults to `true` if not specified.
   - `eol` - String, overrides the default OS line ending (i.e. `\n` on Unix and `\r\n` on Windows).
   - `flatten` - Boolean, flattens nested JSON using [flat]. Defaults to `false`.
   - `unwindPath` - Array of Strings, creates multiple rows from a single JSON document similar to MongoDB's $unwind

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -119,7 +119,7 @@ getFields(function (err, fields) {
     var opts = {
       data: input,
       fields: fields,
-      noHeader: program.noHeader,
+      header: program.header,
       quote: program.quote,
       doubleQuotes: doubleQuotes,
       defaultValue: program.defaultValue,

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace json2csv {
     defaultValue?: string;
     quote?: string;
     doubleQuote?: string;
-    noHeader?: boolean;
+    header?: boolean;
     eol?: string;
     flatten?: boolean;
     unwindPath?: string | string[];

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -20,7 +20,7 @@ var flatten = require('flat');
  * @property {String} [defaultValue="<empty>"] - default value to use when missing data
  * @property {String} [quote='"'] - quote around cell values and column names
  * @property {String} [doubleQuote='""'] - the value to replace double quote in strings
- * @property {Boolean} [noHeader=true] - determines whether or not CSV file will contain a title column
+ * @property {Boolean} [header=true] - determines whether or not CSV file will contain a title column
  * @property {String} [eol=''] - overrides the default OS line ending (\n on Unix \r\n on Windows)
  * @property {Boolean} [flatten=false] - flattens nested JSON using flat (https://www.npmjs.com/package/flat)
  * @property {String[]} [unwindPath] - similar to MongoDB's $unwind, Deconstructs an array field from the input JSON to output a row for each element
@@ -33,7 +33,7 @@ var flatten = require('flat');
  * Main function that converts json to csv.
  *
  * @param {Json2CsvParams} params Function parameters containing data, fields,
- * delimiter (default is ','), noHeader (default is true)
+ * delimiter (default is ','), header (default is true)
  * and default value (default is '')
  * @param {Function} [callback] Callback function
  *   if error, returning error in call back.
@@ -74,7 +74,7 @@ module.exports = function (params, callback) {
  * Note that this modifies params.
  *
  * @param {Json2CsvParams} params Function parameters containing data, fields,
- * delimiter, default value, mark quote and noHeader
+ * delimiter, default value, mark quote and header 
  */
 function checkParams(params) {
   params.data = params.data || [];
@@ -132,8 +132,8 @@ function checkParams(params) {
   //#check default value
   params.defaultValue = params.defaultValue;
 
-  //#check noHeader, if it is not explicitly set to false then true.
-  params.noHeader = params.noHeader !== false;
+  //#check header, if it is not explicitly set to false then true.
+  params.header = params.header !== false;
 
   //#check include empty rows, defaults to false
   params.includeEmptyRows = params.includeEmptyRows || false;
@@ -160,7 +160,7 @@ function createColumnTitles(params) {
   var str = '';
 
   //if CSV has column title, then create it
-  if (params.noHeader) {
+  if (params.header) {
     params.fieldNames.forEach(function (element) {
       if (str !== '') {
         str += params.delimiter;

--- a/test/index.js
+++ b/test/index.js
@@ -115,7 +115,7 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     json2csv({
       data: jsonDefault,
       fields: ['carModel', 'price', 'color'],
-      noHeader: false
+      header: false
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.withoutTitle);


### PR DESCRIPTION
I realized of a couple things from my previous PR and am fixing it with the PR.

* The `noHeaders` option worked as `headers` i.e. it set the headers when set to true. So makes sense to rename it.
* The CLI flag `--no-headers` is a convention from commander. Any flag preceded by `--no` set's it's value to false if present, i.e. `--no-headers` actually sets `headers = false`