### PR TITLE
Avoid throwing an error on elements that can't be stringified

### DIFF
--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -248,39 +248,41 @@ function createColumnContent(params, str) {
             stringifiedElement = JSON.stringify(val);
           }
 
-          if (params.preserveNewLinesInValues && typeof val === 'string') {
-            stringifiedElement = stringifiedElement
-              .replace(/\u2028/g, '\n')
-              .replace(/\u2029/g, '\r');
+          if (stringifiedElement !== undefined) {
+            if (params.preserveNewLinesInValues && typeof val === 'string') {
+              stringifiedElement = stringifiedElement
+                .replace(/\u2028/g, '\n')
+                .replace(/\u2029/g, '\r');
+            }
+
+            if (typeof val === 'object') {
+              // In some cases (e.g. val is a Date), stringifiedElement is already a quoted string.
+              // Strip the leading and trailing quote if so, so we don't end up double-quoting it
+              stringifiedElement = replaceQuotationMarks(stringifiedElement, '');
+
+              // If val is a normal object, we want to escape its JSON so any commas etc
+              // don't get interpreted as field separators
+              stringifiedElement = JSON.stringify(stringifiedElement);
+            }
+
+            if (params.quote !== '"') {
+              stringifiedElement = replaceQuotationMarks(stringifiedElement, params.quote);
+            }
+
+            //JSON.stringify('\\') results in a string with two backslash
+            //characters in it. I.e. '\\\\'.
+            stringifiedElement = stringifiedElement.replace(/\\\\/g, '\\');
+
+            if (params.excelStrings && typeof val === 'string') {
+              stringifiedElement = '"="' + stringifiedElement + '""';
+            }
+
+            //Replace single quote with double quote.  Single quote are preceeded by
+            //a backslash,  and it's not at the end of the stringifiedElement.
+            stringifiedElement = stringifiedElement.replace(/(\\")(?=.)/g, params.doubleQuote);
+
+            line += stringifiedElement;
           }
-
-          if (typeof val === 'object') {
-            // In some cases (e.g. val is a Date), stringifiedElement is already a quoted string.
-            // Strip the leading and trailing quote if so, so we don't end up double-quoting it
-            stringifiedElement = replaceQuotationMarks(stringifiedElement, '');
-
-            // If val is a normal object, we want to escape its JSON so any commas etc
-            // don't get interpreted as field separators
-            stringifiedElement = JSON.stringify(stringifiedElement);
-          }
-
-          if (params.quote !== '"') {
-            stringifiedElement = replaceQuotationMarks(stringifiedElement, params.quote);
-          }
-
-          //JSON.stringify('\\') results in a string with two backslash
-          //characters in it. I.e. '\\\\'.
-          stringifiedElement = stringifiedElement.replace(/\\\\/g, '\\');
-
-          if (params.excelStrings && typeof val === 'string') {
-            stringifiedElement = '"="' + stringifiedElement + '""';
-          }
-
-          //Replace single quote with double quote.  Single quote are preceeded by
-          //a backslash,  and it's not at the end of the stringifiedElement.
-          stringifiedElement = stringifiedElement.replace(/(\\")(?=.)/g, params.doubleQuote);
-
-          line += stringifiedElement;
         }
 
         line += params.delimiter;

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,19 @@ async.parallel(loadFixtures(csvFixtures), function (err) {
     });
   });
 
+  test('should parse json to csv even if json include functions', function (t) {
+    json2csv({
+      data: {
+        a: 1,
+        funct: function (a) { return a + 1; },
+      }
+    }, function (error, csv) {
+      t.error(error);
+      t.equal(csv, '"a","funct"\n1,');
+      t.end();
+    });
+  });
+
   test('should parse data:{} to csv with only column title', function (t) {
     json2csv({
       data: {},


### PR DESCRIPTION
Closes #215 

Some elements can't be stringified. For example functions (`JSON.stringify(() => {})` results on `undefined`).

We didn't handle those case, so json objects with non-stringifiable fields threw an error (not even related to the serialization).

This PR fixes that and add a test to cover this case.