### PR TITLE
Remove path-is-absolute dependency

### DIFF
--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -3,7 +3,6 @@
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
-var isAbsolutePath = require('path-is-absolute');
 var Table = require('cli-table');
 var program = require('commander');
 var debug = require('debug')('json2csv:cli');
@@ -54,8 +53,9 @@ function getInput(callback) {
   var input = '';
 
   if (program.input) {
-    var isAbsolute = isAbsolutePath(program.input);
-    var inputPath = isAbsolute ? program.input : path.join(process.cwd(), program.input);
+    var inputPath = path.isAbsolute(program.input)
+      ? program.input
+      : path.join(process.cwd(), program.input);
 
     if (program.ldjson) {
       fs.readFile(inputPath, 'utf8', function (err, data) {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "lodash.get": "^4.4.0",
     "lodash.set": "^4.3.0",
     "lodash.uniq": "^4.5.0",
-    "lodash.clonedeep": "^4.5.0",
-    "path-is-absolute": "^1.0.0"
+    "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION
`path-is-absolute` is an ancient library. Node has it's own method for it since 0.12.X