### PR TITLE
Add all node versions to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: node_js
 node_js:
   - "0.12"
   - "4"
+  - "5"
   - "6"
+  - "7"
   - "8"
+  - "9"
 script:
   - "npm run test-coverage"
 after_script:


### PR DESCRIPTION
Add all the existing node versions to the travis build.
Is there any reason why this wasn't done before?

I'm currently working on a full refactor to tackle #142. And for that I'll drop support for 0.12. I think that it's very reasonable since 0.12 is not maintained since 2016