### PR TITLE
Rename unwindPath to unwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ try {
   - `header` - Boolean, determines whether or not CSV file will contain a title column. Defaults to `true` if not specified.
   - `eol` - String, overrides the default OS line ending (i.e. `\n` on Unix and `\r\n` on Windows).
   - `flatten` - Boolean, flattens nested JSON using [flat]. Defaults to `false`.
-  - `unwindPath` - Array of Strings, creates multiple rows from a single JSON document similar to MongoDB's $unwind
+  - `unwind` - Array of Strings, creates multiple rows from a single JSON document similar to MongoDB's $unwind
   - `excelStrings` - Boolean, converts string data into normalized Excel style data.
   - `includeEmptyRows` - Boolean, includes empty rows. Defaults to `false`.
   - `preserveNewLinesInValues` - Boolean, preserve \r and \n in values. Defaults to `false`.
@@ -273,7 +273,7 @@ car.make, car.model, price, color
 
 ### Example 7
 
-You can unwind arrays similar to MongoDB's $unwind operation using the `unwindPath` option.
+You can unwind arrays similar to MongoDB's $unwind operation using the `unwind` option.
 
 ```javascript
 var json2csv = require('json2csv');
@@ -298,7 +298,7 @@ var myCars = [
     "colors": ["green","teal","aqua"]
   }
 ];
-var csv = json2csv({ data: myCars, fields: fields, unwindPath: 'colors' });
+var csv = json2csv({ data: myCars, fields: fields, unwind: 'colors' });
 
 fs.writeFile('file.csv', csv, function(err) {
   if (err) throw err;
@@ -372,7 +372,7 @@ var myCars = [
     ]
   }
 ];
-var csv = json2csv({ data: myCars, fields: fields, unwindPath: ['items', 'items.items'] });
+var csv = json2csv({ data: myCars, fields: fields, unwind: ['items', 'items.items'] });
 
 fs.writeFile('file.csv', csv, function(err) {
   if (err) throw err;
@@ -412,7 +412,7 @@ Usage: json2csv [options]
     -q, --quote [value]          Specify an alternate quote value.
     -n, --no-header              Disable the column name header
     -F, --flatten                Flatten nested objects
-    -u, --unwindPath <paths>     Creates multiple rows from a single JSON document similar to MongoDB unwind.
+    -u, --unwind <paths>         Creates multiple rows from a single JSON document similar to MongoDB unwind.
     -L, --ldjson                 Treat the input as Line-Delimited JSON.
     -p, --pretty                 Use only when printing to console. Logs output in pretty tables.
     -a, --include-empty-rows     Includes empty rows in the resulting CSV output.

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Usage: json2csv [options]
     -i, --input <input>          Path and name of the incoming json file.
     -o, --output [output]        Path and name of the resulting csv file. Defaults to console.
     -f, --fields <fields>        Specify the fields to convert.
-    -l, --fieldList [list]       Specify a file with a list of fields to include. One field per line.
+    -l, --field-list [list]       Specify a file with a list of fields to include. One field per line.
     -d, --delimiter [delimiter]  Specify a delimiter other than the default comma to use.
     -e, --eol [value]            Specify an End-of-Line value for separating rows.
     -q, --quote [value]          Specify an alternate quote value.

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -23,7 +23,7 @@ program
   .option('-dq, --doubleQuotes [value]', 'Specify a value to replace double quote in strings')
   .option('-n, --no-header', 'Disable the column name header')
   .option('-F, --flatten', 'Flatten nested objects')
-  .option('-u, --unwindPath <paths>', 'Creates multiple rows from a single JSON document similar to MongoDB unwind.')
+  .option('-u, --unwind <paths>', 'Creates multiple rows from a single JSON document similar to MongoDB unwind.')
   .option('-L, --ldjson', 'Treat the input as Line-Delimited JSON.')
   .option('-p, --pretty', 'Use only when printing to console. Logs output in pretty tables.')
   .option('-a, --include-empty-rows', 'Includes empty rows in the resulting CSV output.')
@@ -136,8 +136,8 @@ getFields(function (err, fields) {
       opts.eol = program.eol;
     }
 
-    if (program.unwindPath) {
-      opts.unwindPath = program.unwindPath.split(',');
+    if (program.unwind) {
+      opts.unwind = program.unwind.split(',');
     }
 
     var csv = json2csv(opts);

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -15,7 +15,7 @@ program
   .option('-i, --input <input>', 'Path and name of the incoming json file. If not provided, will read from stdin.')
   .option('-o, --output [output]', 'Path and name of the resulting csv file. Defaults to stdout.')
   .option('-f, --fields <fields>', 'Specify the fields to convert.')
-  .option('-l, --fieldList [list]', 'Specify a file with a list of fields to include. One field per line.')
+  .option('-l, --field-list [list]', 'Specify a file with a list of fields to include. One field per line.')
   .option('-d, --delimiter [delimiter]', 'Specify a delimiter other than the default comma to use.')
   .option('-v, --defaultValue [defaultValue]', 'Specify a default value other than empty string.')
   .option('-e, --eol [value]', 'Specify an End-of-Line value for separating rows.')

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare namespace json2csv {
     header?: boolean;
     eol?: string;
     flatten?: boolean;
-    unwindPath?: string | string[];
+    unwind?: string | string[];
     excelStrings?: boolean;
     includeEmptyRows?: boolean;
     preserveNewLinesInValues?: boolean;

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -23,7 +23,7 @@ var flatten = require('flat');
  * @property {Boolean} [header=true] - determines whether or not CSV file will contain a title column
  * @property {String} [eol=''] - overrides the default OS line ending (\n on Unix \r\n on Windows)
  * @property {Boolean} [flatten=false] - flattens nested JSON using flat (https://www.npmjs.com/package/flat)
- * @property {String[]} [unwindPath] - similar to MongoDB's $unwind, Deconstructs an array field from the input JSON to output a row for each element
+ * @property {String[]} [unwind] - similar to MongoDB's $unwind, Deconstructs an array field from the input JSON to output a row for each element
  * @property {Boolean} [excelStrings] - converts string data into normalized Excel style data
  * @property {Boolean} [includeEmptyRows=false] - includes empty rows
  * @property {Boolean} [withBOM=false] - includes BOM character at the beginning of the csv
@@ -140,12 +140,12 @@ function checkParams(params) {
   // check with BOM, defaults to false
   params.withBOM = params.withBOM || false;
 
-  // check unwindPath, defaults to empty array
-  params.unwindPath = params.unwindPath || [];
+  // check unwind, defaults to empty array
+  params.unwind = params.unwind || [];
 
-  // if unwindPath is not in array [{}], then just create 1 item array.
-  if (!Array.isArray(params.unwindPath)) {
-    params.unwindPath = [params.unwindPath];
+  // if unwind is not in array [{}], then just create 1 item array.
+  if (!Array.isArray(params.unwind)) {
+    params.unwind = [params.unwind];
   }
 }
 
@@ -204,7 +204,7 @@ function replaceQuotationMarks(stringifiedElement, quote) {
  * @returns {String} csv string
  */
 function createColumnContent(params, str) {
-  createDataRows(params.data, params.unwindPath).forEach(function (dataElement) {
+  createDataRows(params.data, params.unwind).forEach(function (dataElement) {
     // if null do nothing, if empty object without includeEmptyRows do nothing
     if (dataElement && (Object.getOwnPropertyNames(dataElement).length > 0 || params.includeEmptyRows)) {
       var line = '';
@@ -311,7 +311,7 @@ function createColumnContent(params, str) {
  * Performs the unwind recursively in specified sequence
  *
  * @param {Array} originalData The params.data value. Original array of JSON objects
- * @param {String[]} unwindPaths The params.unwindPath value. Unwind strings to be used to deconstruct array
+ * @param {String[]} unwindPaths The params.unwind value. Unwind strings to be used to deconstruct array
  * @returns {Array} Array of objects containing all rows after unwind of chosen paths
  */
 function createDataRows(originalData, unwindPaths) {
@@ -321,8 +321,8 @@ function createDataRows(originalData, unwindPaths) {
     originalData.forEach(function (dataElement) {
       var dataRow = [dataElement];
 
-      unwindPaths.forEach(function (unwindPath) {
-        dataRow = unwindRows(dataRow, unwindPath);
+      unwindPaths.forEach(function (unwind) {
+        dataRow = unwindRows(dataRow, unwind);
       });
 
       Array.prototype.push.apply(dataRows, dataRow);
@@ -338,25 +338,25 @@ function createDataRows(originalData, unwindPaths) {
  * Performs the unwind logic if necessary to convert single JSON document into multiple rows
  *
  * @param {Array} inputRows Array contaning single or multiple rows to unwind
- * @param {String} unwindPath Single path to do unwind
+ * @param {String} unwind Single path to do unwind
  * @returns {Array} Array of rows processed
  */
-function unwindRows(inputRows, unwindPath) {
+function unwindRows(inputRows, unwind) {
   var outputRows = [];
   
   inputRows.forEach(function (dataEl) {
-    var unwindArray = lodashGet(dataEl, unwindPath);
+    var unwindArray = lodashGet(dataEl, unwind);
     var isArr = Array.isArray(unwindArray);
 
     if (isArr && unwindArray.length) {
       unwindArray.forEach(function (unwindEl) {
         var dataCopy = lodashCloneDeep(dataEl);
-        lodashSet(dataCopy, unwindPath, unwindEl);
+        lodashSet(dataCopy, unwind, unwindEl);
         outputRows.push(dataCopy);
       });
     } else if (isArr && !unwindArray.length) {
       var dataCopy = lodashCloneDeep(dataEl);
-      lodashSet(dataCopy, unwindPath, undefined);
+      lodashSet(dataCopy, unwind, undefined);
       outputRows.push(dataCopy);
     } else {
       outputRows.push(dataEl);

--- a/test/index.js
+++ b/test/index.js
@@ -684,7 +684,7 @@ loadFixtures().then(function (csvFixtures) {
     json2csv({
       data: jsonUnwind,
       fields: ['carModel', 'price', 'colors'],
-      unwindPath: 'colors'
+      unwind: 'colors'
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.unwind);
@@ -696,7 +696,7 @@ loadFixtures().then(function (csvFixtures) {
     json2csv({
       data: jsonUnwind2,
       fields: ['carModel', 'price', 'items.name', 'items.color', 'items.items.position', 'items.items.color'],
-      unwindPath: ['items', 'items.items']
+      unwind: ['items', 'items.items']
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.unwind2);


### PR DESCRIPTION
Since we are breaking the API for the next version. Let's try to make it as good as possible.

This PR rename `unwindPath` to just `unwind` which is nicer and cleaner.

I'd suggest that you guys take a look at the current options to see if there is anything that could be improve. I'm happy to do the changes if you just let me know.