### PR TITLE
Remove fieldNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ try {
 - `options` - **Required**; Options hash.
   - `data` - **Required**; Array of JSON objects.
   - `fields` - Array of Objects/Strings. Defaults to toplevel JSON attributes. See example below.
-  - `fieldNames` Array of Strings, names for the fields at the same indexes.
-    Must be the same length as `fields` array. (Optional. Maintained for backwards compatibility. Use `fields` config object for more features)
   - `delimiter` - String, delimiter of columns. Defaults to `,` if not specified.
   - `defaultValue` - String, default value to use when missing data. Defaults to `<empty>` if not specified. (Overridden by `fields[].default`)
   - `quote` - String, quote around cell values and column names. Defaults to `"` if not specified.
@@ -196,9 +194,14 @@ You can choose custom column names for the exported file.
 
 ```javascript
 var json2csv = require('json2csv');
-var fields = ['car', 'price'];
-var fieldNames = ['Car Name', 'Price USD'];
-var csv = json2csv({ data: myCars, fields: fields, fieldNames: fieldNames });
+var fields = [{
+  label: 'Car Name',
+  value: 'car'
+},{
+  label: 'Price USD',
+  value: 'price'
+}];
+var csv = json2csv({ data: myCars, fields: fields });
 
 console.log(csv);
 ```
@@ -210,11 +213,9 @@ You can choose custom quotation marks.
 ```javascript
 var json2csv = require('json2csv');
 var fields = ['car', 'price'];
-var fieldNames = ['Car Name', 'Price USD'];
 var opts = {
   data: myCars,
   fields: fields,
-  fieldNames: fieldNames,
   quote: ''
 };
 var csv = json2csv(opts);

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,6 @@ declare namespace json2csv {
   interface Options<T> {
     data: T[];
     fields?: (string | Field | CallbackField<T>)[];
-    fieldNames?: string[];
     delimiter?: string;
     defaultValue?: string;
     quote?: string;

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -101,11 +101,10 @@ function checkParams(params) {
   }
 
   // Get fieldNames from fields
-  params.fieldNames = params.fields.map(function (field, i) {
-    if (params.fieldNames && typeof field === 'string') {
-      return params.fieldNames[i];
-    }
-    return (typeof field === 'string') ? field : (field.label || field.value);
+  params.fieldNames = params.fields.map(function (field) {
+    return (typeof field === 'string')
+      ? field
+      : (field.label || field.value);
   });
 
   // check delimiter

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -14,8 +14,6 @@ var flatten = require('flat');
  * @typedef {Object}
  * @property {Array} data - array of JSON objects
  * @property {Array} [fields] - see documentation for details
- * @property {String[]} [fieldNames] - names for fields at the same indexes. Must be same length as fields array
- *                                   (Optional. Maintained for backwards compatibility. Use fields config object for more features)
  * @property {String} [delimiter=","] - delimiter of columns
  * @property {String} [defaultValue="<empty>"] - default value to use when missing data
  * @property {String} [quote='"'] - quote around cell values and column names
@@ -100,12 +98,6 @@ function checkParams(params) {
 
     dataFields = lodashFlatten(dataFields);
     params.fields = lodashUniq(dataFields);
-  }
-
-
-  // check fieldNames
-  if (params.fieldNames && params.fieldNames.length !== params.fields.length) {
-    throw new Error('fieldNames and fields should be of the same length, if fieldNames is provided.');
   }
 
   // Get fieldNames from fields

--- a/test/index.js
+++ b/test/index.js
@@ -318,7 +318,22 @@ loadFixtures().then(function (csvFixtures) {
     });
   });
 
-  test('should error if params is not an object', function (t) {
+  test('should error synchronously if fieldNames don\'t line up to fields', function (t) {
+    var csv;
+    try {
+      csv = json2csv({
+        data: 'not an object',
+        field: ['carModel'],
+      });
+      t.notOk(true);
+    } catch (error) {
+      t.equal(error.message, 'params should include "fields" and/or non-empty "data" array of objects');
+      t.notOk(csv);
+      t.end();
+    }
+  });
+
+  test('should error asynchronously if params is not an object', function (t) {
     json2csv({
       data: 'not an object',
       field: ['carModel'],

--- a/test/index.js
+++ b/test/index.js
@@ -54,34 +54,6 @@ loadFixtures().then(function (csvFixtures) {
     });
   });
 
-  test('should error synchronously if fieldNames don\'t line up to fields', function (t) {
-    var csv;
-    try {
-      csv = json2csv({
-        data: jsonDefault,
-        field: ['carModel'],
-        fieldNames: ['test', 'blah']
-      });
-      t.notOk(true);
-    } catch (error) {
-      t.equal(error.message, 'fieldNames and fields should be of the same length, if fieldNames is provided.');
-      t.notOk(csv);
-      t.end();
-    }
-  });
-
-  test('should error asynchronously if fieldNames don\'t line up to fields', function (t) {
-    json2csv({
-      data: jsonDefault,
-      field: ['carModel'],
-      fieldNames: ['test', 'blah']
-    }, function (error, csv) {
-      t.equal(error.message, 'fieldNames and fields should be of the same length, if fieldNames is provided.');
-      t.notOk(csv);
-      t.end();
-    });
-  });
-
   test('should parse json to csv', function (t) {
     json2csv({
       data: jsonDefault,
@@ -279,11 +251,16 @@ loadFixtures().then(function (csvFixtures) {
     });
   });
 
-  test('should name columns as specified in \'fieldNames\' property', function (t) {
+  test('should name columns as specified in \'fields\' property', function (t) {
     json2csv({
       data: jsonDefault,
-      fields: ['carModel', 'price'],
-      fieldNames: ['Car Model', 'Price USD']
+      fields: [{
+        label: 'Car Model',
+        value: 'carModel'
+      },{
+        label: 'Price USD',
+        value: 'price'
+      }]
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.fieldNames);
@@ -294,8 +271,22 @@ loadFixtures().then(function (csvFixtures) {
   test('should output nested properties', function (t) {
     json2csv({
       data: jsonNested,
-      fields: ['car.make', 'car.model', 'price', 'color', 'car.ye.ar'],
-      fieldNames: ['Make', 'Model', 'Price', 'Color', 'Year']
+      fields: [{
+        label: 'Make',
+        value: 'car.make'
+      },{
+        label: 'Model',
+        value: 'car.model'
+      },{
+        label: 'Price',
+        value: 'price'
+      },{
+        label: 'Color',
+        value: 'color'
+      },{
+        label: 'Year',
+        value: 'car.ye.ar'
+      }]
     }, function (error, csv) {
       t.error(error);
       t.equal(csv, csvFixtures.nested);
@@ -331,7 +322,6 @@ loadFixtures().then(function (csvFixtures) {
     json2csv({
       data: 'not an object',
       field: ['carModel'],
-      fieldNames: ['test', 'blah']
     }, function (error, csv) {
       t.equal(error.message, 'params should include "fields" and/or non-empty "data" array of objects');
       t.notOk(csv);


### PR DESCRIPTION
`fieldNames` API is just wrong. It does exactly the same as fields does but in a worse manner.

It said in the comments and docs that it was there for backwards compatibility. Since we are already breaking it in many way, let's get rid of this one.

took me two minute to modify the tests to run using `fields` instead `fieldNames`