### PR TITLE
Fix flatten issue with toJSON

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -4,7 +4,6 @@ const os = require('os');
 const lodashGet = require('lodash.get');
 const lodashSet = require('lodash.set');
 const lodashCloneDeep = require('lodash.clonedeep');
-const flatten = require('flat');
 
 class JSON2CSVBase {
   constructor(opts) {
@@ -64,7 +63,7 @@ class JSON2CSVBase {
       ? this.unwindData(row, this.opts.unwind)
       : [row];
     if (this.opts.flatten) {
-      return processedRow.map(flatten);
+      return processedRow.map(this.flatten);
     }
 
     return processedRow;
@@ -193,9 +192,41 @@ class JSON2CSVBase {
   }
 
   /**
+   * Performs the flattening of a data row recursively
+   *
+   * @param {Object} dataRow Original JSON object
+   * @returns {Object} Flattened object
+   */
+  flatten(dataRow) {
+    function step (obj, flatDataRow, currentPath) {
+      Object.keys(obj).forEach((key) => {
+        const value = obj[key];
+
+        const newPath = currentPath
+          ? `${currentPath}.${key}`
+          : key;
+
+        if (typeof value !== 'object'
+          || Array.isArray(value)
+          || Object.prototype.toString.call(value.toJSON) === '[object Function]'
+          || !Object.keys(value).length) {
+          flatDataRow[newPath] = value;
+          return;
+        }
+
+        step(value, flatDataRow, newPath);
+      });
+
+      return flatDataRow;
+    }
+
+    return step(dataRow, {});
+  }
+
+  /**
    * Performs the unwind recursively in specified sequence
    *
-   * @param {Array} dataRow Original JSON object
+   * @param {Object} dataRow Original JSON object
    * @param {String[]} unwindPaths The paths as strings to be used to deconstruct the array
    * @returns {Array} Array of objects containing all rows after unwind of chosen paths
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,14 +2622,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "flat": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.0.0.tgz",
-      "integrity": "sha1-Orx/O1iOZM533EL9Wao1gGYi/qg=",
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
     "flat-arguments": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flat-arguments/-/flat-arguments-1.0.2.tgz",
@@ -4487,7 +4479,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -5078,7 +5071,8 @@
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
     },
     "lodash.foreach": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,8 @@
   "dependencies": {
     "cli-table2": "^0.2.0",
     "commander": "^2.8.1",
-    "flat": "^4.0.0",
     "jsonparse": "^1.3.1",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.0",
     "lodash.set": "^4.3.0"
   },

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -275,6 +275,18 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.end();
   });
 
+  testRunner.add('should support flattenning JSON with toJSON', (t) => {
+    const opts = {
+      flatten: true
+    };
+
+    const parser = new Json2csvParser(opts);
+    const csv = parser.parse(jsonFixtures.flattenToJSON);
+
+    t.equal(csv, csvFixtures.flattenToJSON);
+    t.end();
+  });
+
   testRunner.add('should unwind and flatten an object in the right order', (t) => {
     const opts = {
       unwind: ['items'],

--- a/test/fixtures/csv/flattenToJSON.csv
+++ b/test/fixtures/csv/flattenToJSON.csv
@@ -1,0 +1,2 @@
+"hello.world","lorem.ipsum.dolor"
+"good afternoon","good evening"

--- a/test/fixtures/json/flattenToJSON.js
+++ b/test/fixtures/json/flattenToJSON.js
@@ -1,0 +1,13 @@
+module.exports = {
+  hello: {
+    world: {
+      again: 'good morning',
+      toJSON: () =>'good afternoon'
+    }
+  },
+  lorem: {
+    ipsum: {
+      dolor: 'good evening'
+    }
+  }
+} 


### PR DESCRIPTION
Closes #175 and supersedes #196 

Flatten an object is a trivial task. There was no reason to use a library since we don't use any of the extra functionality. Specially when the library is not maintained.

So I've added the logic as we did with unwind.