### PR TITLE
Pass transform options through

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,11 @@ const Json2csvTransform = require('json2csv').Transform;
 
 const fields = ['field1', 'field2', 'field3'];
 const opts = { fields };
+const transformOpts = { highWaterMark: 16384, encoding: 'utf-8' };
 
 const input = fs.createReadStream(inputPath, { encoding: 'utf8' });
 const output = fs.createWriteStream(outputPath, { encoding: 'utf8' });
-const json2csv = new Json2csvTransform(opts);
+const json2csv = new Json2csvTransform(opts, transformOpts);
 
 const processor = input.pipe(json2csv).pipe(output);
 

--- a/lib/JSON2CSVTransform.js
+++ b/lib/JSON2CSVTransform.js
@@ -5,8 +5,8 @@ const Parser = require('jsonparse');
 const JSON2CSVBase = require('./JSON2CSVBase');
 
 class JSON2CSVTransform extends Transform {
-  constructor(opts) {
-    super(opts);
+  constructor(opts, transformOpts) {
+    super(transformOpts);
 
     // Inherit methods from JSON2CSVBase since extends doesn't
     // allow multiple inheritance and manually preprocess opts


### PR DESCRIPTION
Much better and cleaner to separate the json2csv options from the stream options.