### PR TITLE
Fix issue with quote character immediately before line break

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -181,7 +181,7 @@ class JSON2CSVBase {
     //a backslash, and it's not at the end of the stringifiedValue.
     stringifiedValue = stringifiedValue
       .replace(/^"(.*)"$/, this.opts.quote + '$1' + this.opts.quote)
-      .replace(/(\\")(?=.)/g, this.opts.doubleQuote)
+      .replace(/(\\")(?=[/s/S])/g, this.opts.doubleQuote)
       .replace(/\\\\/g, '\\');
 
     if (this.opts.excelStrings && typeof value === 'string') {


### PR DESCRIPTION
# The issue:

The CSV output is not correct if a value contains a double-quote character (`"`) immediately before a line break. For example:

```javascript
const obj = {
    key: `value "with quotes"
        and line break`
};
json2csv.parse(data, { fields: ["key"] });
```

Expected CSV output:

```csv
"key"
"value ""with quotes""
        and line break"
```

Actual CSV output:

```csv
"key"
"value ""with quotes\"
        and line break"
```

Neither Microsoft Excel nor [csvtojson](https://github.com/Keyang/node-csvtojson) interprets the `\"` correctly. It should be a double-double quote (`""`) like all other escaped double-quotes.

# The fix:

`[/s/S]` matches all characters, including line breaks (but `.` does not match line breaks).