### PR TITLE
Add ability to unwind by blanking out instead of repeating data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $ npm install json2csv --save
     -f, --fields <fields>               Specify the fields to convert.
     -c, --fields-config [list]          Specify a file with a fields configuration as a JSON array.
     -u, --unwind <paths>                Creates multiple rows from a single JSON document similar to MongoDB unwind.
+    -B, --unwind-blank                  When unwinding, blank out instead of repeating data.
     -F, --flatten                       Flatten nested objects
     -v, --default-value [defaultValue]  Specify a default value other than empty string.
     -q, --quote [value]                 Specify an alternate quote value.
@@ -155,6 +156,7 @@ The programatic APIs take a configuration object very equivalent to the CLI opti
 - `fields` - Array of Objects/Strings. Defaults to toplevel JSON attributes. See example below.
 - `ndjson` - Only effective on the streaming API. Indicates that data coming through the stream is NDJSON.
 - `unwind` - Array of Strings, creates multiple rows from a single JSON document similar to MongoDB's $unwind
+- `unwindBlank` - Boolean, unwind using blank values instead of repeating data.
 - `flatten` - Boolean, flattens nested JSON using [flat]. Defaults to `false`.
 - `defaultValue` - String, default value to use when missing data. Defaults to `<empty>` if not specified. (Overridden by `fields[].default`)
 - `quote` - String, quote around cell values and column names. Defaults to `"` if not specified.

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -23,6 +23,7 @@ program
   .option('-f, --fields <fields>', 'Specify the fields to convert.')
   .option('-c, --fields-config <path>', 'Specify a file with a fields configuration as a JSON array.')
   .option('-u, --unwind <paths>', 'Creates multiple rows from a single JSON document similar to MongoDB unwind.')
+  .option('-B, --unwind-blank', 'When unwinding, blank out instead of repeating data.')
   .option('-F, --flatten', 'Flatten nested objects')
   .option('-v, --default-value [defaultValue]', 'Specify a default value other than empty string.')
   .option('-q, --quote [value]', 'Specify an alternate quote value.')
@@ -143,6 +144,7 @@ Promise.resolve()
     const opts = {
       fields: getFields(),
       unwind: program.unwind ? program.unwind.split(',') : [],
+      unwindBlank: program.unwindBlank,
       flatten: program.flatten,
       defaultValue: program.defaultValue,
       quote: program.quote,

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -243,8 +243,18 @@ class JSON2CSVBase {
           }
 
           if (unwindArray.length) {
-            return unwindArray.map((unwindEl) => {
+            return unwindArray.map((unwindEl, index) => {
               const dataCopy = lodashCloneDeep(dataEl);
+
+              if (this.opts.unwindBlank && index > 0) {
+                Object.keys(dataCopy).forEach(key => {
+                  if (!unwindEl[key]) {
+                    dataCopy[key] = null;
+                  }
+                })
+              }
+
+
               lodashSet(dataCopy, unwindPath, unwindEl);
               return dataCopy;
             });

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -275,6 +275,21 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.end();
   });
 
+  testRunner.add('should unwind and blank out repeated data', (t) => {
+    const opts = {
+      fields: ['carModel', 'price', 'items.name', 'items.color', 'items.items.position', 'items.items.color'],
+      unwind: ['items', 'items.items'],
+      unwindBlank: true,
+    };
+
+    const parser = new Json2csvParser(opts);
+    const csv = parser.parse(jsonFixtures.unwind2);
+
+    t.equal(csv, csvFixtures.unwind2Blank);
+    t.end();
+  });
+
+
   testRunner.add('should support flattenning deep JSON', (t) => {
     const opts = {
       flatten: true

--- a/test/fixtures/csv/unwind2Blank.csv
+++ b/test/fixtures/csv/unwind2Blank.csv
@@ -1,0 +1,7 @@
+"carModel","price","items.name","items.color","items.items.position","items.items.color"
+"BMW",15000,"airbag","white",,
+,,"dashboard","black",,
+"Porsche",30000,"airbag",,"left","white"
+,,,,"right","gray"
+,,"dashboard",,"left","gray"
+,,,,"right","black"


### PR DESCRIPTION
I do this a lot when I want to present nested data to non-technical users, who find it easer to read in spreadsheets.

Without `--unwind-blank`:

![image](https://user-images.githubusercontent.com/572/38783709-24a0a708-4106-11e8-8973-ee62968fac99.png)

With `--unwind-blank`:

![image](https://user-images.githubusercontent.com/572/38783717-3d18bb2c-4106-11e8-82d2-3215aa305064.png)


