### PR TITLE
Avoid redundant deep cloning when unwinding.

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -234,8 +234,12 @@ class JSON2CSVBase {
    */
   unwindData(dataRow, unwindPaths) {
     return unwindPaths
-      .reduce((data, unwindPath) =>
-        data.map((dataEl) => {
+      .reduce((data, unwindPath) => {
+        function clone(o) {
+          return unwindPath.indexOf('.') !== -1 ? lodashCloneDeep(o) : Object.assign({}, o);
+        }
+
+        return data.map((dataEl) => {
           const unwindArray = lodashGet(dataEl, unwindPath);
 
           if (!Array.isArray(unwindArray)) {
@@ -244,7 +248,7 @@ class JSON2CSVBase {
 
           if (unwindArray.length) {
             return unwindArray.map((unwindEl, index) => {
-              const dataCopy = lodashCloneDeep(dataEl);
+              const dataCopy = clone(dataEl);
 
               if (this.opts.unwindBlank && index > 0) {
                 Object.keys(dataCopy).forEach(key => {
@@ -254,16 +258,16 @@ class JSON2CSVBase {
                 })
               }
 
-
               lodashSet(dataCopy, unwindPath, unwindEl);
               return dataCopy;
             });
           }
 
-          const dataCopy = lodashCloneDeep(dataEl);
+          const dataCopy = clone(dataEl);
           lodashSet(dataCopy, unwindPath, undefined);
           return dataCopy;
-        }).reduce((tempData, rows) => tempData.concat(rows), []),
+        }).reduce((tempData, rows) => tempData.concat(rows), [])
+      },
       [dataRow]
     )
     .reduce((tempData, rows) => tempData.concat(rows), []);

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -78,7 +78,7 @@ class JSON2CSVBase {
    */
   processRow(row) {
     if (!row
-        || (Object.getOwnPropertyNames(row).length === 0 
+        || (Object.getOwnPropertyNames(row).length === 0
           && !this.opts.includeEmptyRows)) {
       return undefined;
     }
@@ -114,7 +114,7 @@ class JSON2CSVBase {
     const defaultValue = typeof fieldInfo === 'object' && 'default' in fieldInfo
       ? fieldInfo.default
       : this.opts.defaultValue;
-    
+
     let value;
     if (fieldInfo) {
       if (typeof fieldInfo === 'string') {
@@ -233,44 +233,38 @@ class JSON2CSVBase {
    * @returns {Array} Array of objects containing all rows after unwind of chosen paths
    */
   unwindData(dataRow, unwindPaths) {
-    return unwindPaths
-      .reduce((data, unwindPath) => {
+    const unwind = (rows, unwindPath) => {
         function clone(o) {
           return unwindPath.indexOf('.') !== -1 ? lodashCloneDeep(o) : Object.assign({}, o);
         }
 
-        return data.map((dataEl) => {
-          const unwindArray = lodashGet(dataEl, unwindPath);
+        return rows.map(row => {
+          const unwindArray = lodashGet(row, unwindPath);
 
           if (!Array.isArray(unwindArray)) {
-            return dataEl;
+            return row;
           }
 
-          if (unwindArray.length) {
-            return unwindArray.map((unwindEl, index) => {
-              const dataCopy = clone(dataEl);
-
-              if (this.opts.unwindBlank && index > 0) {
-                Object.keys(dataCopy).forEach(key => {
-                  if (!unwindEl[key]) {
-                    dataCopy[key] = null;
-                  }
-                })
-              }
-
-              lodashSet(dataCopy, unwindPath, unwindEl);
-              return dataCopy;
-            });
+          if (!unwindArray.length) {
+            return lodashSet(clone(row), unwindPath, undefined);
           }
 
-          const dataCopy = clone(dataEl);
-          lodashSet(dataCopy, unwindPath, undefined);
-          return dataCopy;
-        }).reduce((tempData, rows) => tempData.concat(rows), [])
-      },
-      [dataRow]
-    )
-    .reduce((tempData, rows) => tempData.concat(rows), []);
+          return unwindArray.map((unwindRow, index) => {
+            const clonedRow = clone(row);
+            const shouldBlank = this.opts.unwindBlank && index > 0;
+
+            if (shouldBlank) {
+              const parentKeys = Object.keys(clonedRow).filter(key => !unwindRow[key])
+              parentKeys.forEach(key => (clonedRow[key] = null));
+            }
+
+            return lodashSet(clonedRow, unwindPath, unwindRow);
+          });
+        }).reduce((a, e) => a.concat(e), [])
+      }
+
+    return unwindPaths
+      .reduce(unwind, [dataRow])
   }
 }
 

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -231,14 +231,17 @@ class JSON2CSVBase {
    * @param {Object} dataRow Original JSON object
    * @param {String[]} unwindPaths The paths as strings to be used to deconstruct the array
    * @returns {Array} Array of objects containing all rows after unwind of chosen paths
-   */
+  */
   unwindData(dataRow, unwindPaths) {
     const unwind = (rows, unwindPath) => {
-        function clone(o) {
-          return unwindPath.indexOf('.') !== -1 ? lodashCloneDeep(o) : Object.assign({}, o);
-        }
+      function clone(o) {
+        return unwindPath.indexOf('.') !== -1
+          ? lodashCloneDeep(o)
+          : Object.assign({}, o);
+      }
 
-        return rows.map(row => {
+      return rows
+        .map(row => {
           const unwindArray = lodashGet(row, unwindPath);
 
           if (!Array.isArray(unwindArray)) {
@@ -254,17 +257,19 @@ class JSON2CSVBase {
             const shouldBlank = this.opts.unwindBlank && index > 0;
 
             if (shouldBlank) {
-              const parentKeys = Object.keys(clonedRow).filter(key => !unwindRow[key])
+              const parentKeys = Object.keys(clonedRow).filter(
+                key => !unwindRow[key]
+              );
               parentKeys.forEach(key => (clonedRow[key] = null));
             }
 
             return lodashSet(clonedRow, unwindPath, unwindRow);
           });
-        }).reduce((a, e) => a.concat(e), [])
-      }
+        })
+        .reduce((a, e) => a.concat(e), []);
+    };
 
-    return unwindPaths
-      .reduce(unwind, [dataRow])
+    return unwindPaths.reduce(unwind, [dataRow]);
   }
 }
 


### PR DESCRIPTION
AFAICT there's no reason to deep clone unless the unwind path has multiple levels. For large and deeply nested objects this should be a significant performance gain.