### PR TITLE
Add tests and docs to unwind-blank feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,75 @@ will output to console
 "Porsche",30000,"dashboard",,"right","black"
 ```
 
+#### Example 9
+
+You can also unwind arrays blanking the repeated fields.
+
+```javascript
+const Json2csvParser = require('json2csv').Parser;
+const fields = ['carModel', 'price', 'items.name', 'items.color', 'items.items.position', 'items.items.color'];
+const myCars = [
+  {
+    "carModel": "BMW",
+    "price": 15000,
+    "items": [
+      {
+        "name": "airbag",
+        "color": "white"
+      }, {
+        "name": "dashboard",
+        "color": "black"
+      }
+    ]
+  }, {
+    "carModel": "Porsche",
+    "price": 30000,
+    "items": [
+      {
+        "name": "airbag",
+        "items": [
+          {
+            "position": "left",
+            "color": "white"
+          }, {
+            "position": "right",
+            "color": "gray"
+          }
+        ]
+      }, {
+        "name": "dashboard",
+        "items": [
+          {
+            "position": "left",
+            "color": "gray"
+          }, {
+            "position": "right",
+            "color": "black"
+          }
+        ]
+      }
+    ]
+  }
+];
+
+const json2csvParser = new Json2csvParser({ fields, unwind: ['items', 'items.items'], unwindBlank: true });
+const csv = json2csvParser.parse(myCars);
+
+console.log(csv);
+```
+
+will output to console
+
+```
+"carModel","price","items.name","items.color","items.items.position","items.items.color"
+"BMW",15000,"airbag","white",,
+,,"dashboard","black",,
+"Porsche",30000,"airbag",,"left","white"
+,,,,"right","gray"
+,,"dashboard",,"left","gray"
+,,,,"right","black"
+```
+
 ### Migrating from 3.X to 4.X
 
 What in 3.X used to be

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -301,6 +301,18 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     });
   });
 
+  testRunner.add('hould unwind and blank out repeated data', (t) => {
+    const opts = ' --fields carModel,price,items.name,items.color,items.items.position,items.items.color'
+      + ' --unwind items,items.items --unwind-blank';
+
+    child_process.exec(cli + '-i ' + getFixturePath('/json/unwind2.json') + opts, (err, stdout, stderr) => {
+      t.notOk(stderr);
+      const csv = stdout;
+      t.equal(csv, csvFixtures.unwind2Blank);
+      t.end();
+    });
+  });
+
   testRunner.add('should support flattenning deep JSON', (t) => {
     const opts = ' --flatten';
 

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -279,7 +279,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     const opts = {
       fields: ['carModel', 'price', 'items.name', 'items.color', 'items.items.position', 'items.items.color'],
       unwind: ['items', 'items.items'],
-      unwindBlank: true,
+      unwindBlank: true
     };
 
     const parser = new Json2csvParser(opts);

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -414,6 +414,28 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       .on('error', err => t.notOk(true, err.message));
   });
 
+
+
+  testRunner.add('should unwind and blank out repeated data', (t) => {
+    const opts = {
+      fields: ['carModel', 'price', 'items.name', 'items.color', 'items.items.position', 'items.items.color'],
+      unwind: ['items', 'items.items'],
+      unwindBlank: true
+    };
+
+    const transform = new Json2csvTransform(opts);
+    const processor = jsonFixtures.unwind2().pipe(transform);
+
+    let csv = '';
+    processor
+      .on('data', chunk => (csv += chunk.toString()))
+      .on('end', () => {
+        t.equal(csv, csvFixtures.unwind2Blank);
+        t.end();
+      })
+      .on('error', err => t.notOk(true, err.message));
+  });
+
   testRunner.add('should support flattenning deep JSON', (t) => {
     const opts = {
       flatten: true


### PR DESCRIPTION
This adds the missing tests and an example to the documentation for #285.

Also, it removes the trailing comma.
I like trailing commas ala air-bnb. However, we don't use them anywhere in the code base and I think that consistency is important.