### PR TITLE
Added flattenSeparator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,27 +45,28 @@ $ npm install json2csv --save
 
   Options:
 
-    -V, --version                       output the version number
-    -i, --input <input>                 Path and name of the incoming json file. If not provided, will read from stdin.
-    -o, --output [output]               Path and name of the resulting csv file. Defaults to stdout.
-    -n, --ndjson                        Treat the input as NewLine-Delimited JSON.
-    -s, --no-streaming                  Process the whole JSON array in memory instead of doing it line by line.
-    -f, --fields <fields>               Specify the fields to convert.
-    -c, --fields-config <path>          Specify a file with a fields configuration as a JSON array.
-    -u, --unwind <paths>                Creates multiple rows from a single JSON document similar to MongoDB unwind.
-    -B, --unwind-blank                  When unwinding, blank out instead of repeating data.
-    -F, --flatten                       Flatten nested objects
-    -v, --default-value [defaultValue]  Specify a default value other than empty string.
-    -q, --quote [value]                 Specify an alternate quote value.
-    -Q, --double-quote [value]          Specify a value to replace double quote in strings
-    -d, --delimiter [delimiter]         Specify a delimiter other than the default comma to use.
-    -e, --eol [value]                   Specify an End-of-Line value for separating rows.
-    -E, --excel-strings                 Converts string data into normalized Excel style data
-    -H, --no-header                     Disable the column name header
-    -a, --include-empty-rows            Includes empty rows in the resulting CSV output.
-    -b, --with-bom                      Includes BOM character at the beginning of the csv.
-    -p, --pretty                        Use only when printing to console. Logs output in pretty tables.
-    -h, --help                          output usage information
+    -V, --version                        output the version number
+    -i, --input <input>                  Path and name of the incoming json file. If not provided, will read from stdin.
+    -o, --output [output]                Path and name of the resulting csv file. Defaults to stdout.
+    -n, --ndjson                         Treat the input as NewLine-Delimited JSON.
+    -s, --no-streaming                   Process the whole JSON array in memory instead of doing it line by line.
+    -f, --fields <fields>                Specify the fields to convert.
+    -c, --fields-config <path>           Specify a file with a fields configuration as a JSON array.
+    -u, --unwind <paths>                 Creates multiple rows from a single JSON document similar to MongoDB unwind.
+    -B, --unwind-blank                   When unwinding, blank out instead of repeating data.
+    -F, --flatten                        Flatten nested objects.
+    -S, --flatten-separator <separator>  Flattened keys separator.
+    -v, --default-value [defaultValue]   Specify a default value other than empty string.
+    -q, --quote [value]                  Specify an alternate quote value.
+    -Q, --double-quote [value]           Specify a value to replace double quote in strings.
+    -d, --delimiter [delimiter]          Specify a delimiter other than the default comma to use.
+    -e, --eol [value]                    Specify an End-of-Line value for separating rows.
+    -E, --excel-strings                  Converts string data into normalized Excel style data.
+    -H, --no-header                      Disable the column name header.
+    -a, --include-empty-rows             Includes empty rows in the resulting CSV output.
+    -b, --with-bom                       Includes BOM character at the beginning of the csv.
+    -p, --pretty                         Use only when printing to console. Logs output in pretty tables.
+    -h, --help                           output usage information
 ```
 
 An input file `-i` and fields `-f` are required. If no output `-o` is specified the result is logged to the console.
@@ -158,6 +159,7 @@ The programatic APIs take a configuration object very equivalent to the CLI opti
 - `unwind` - Array of Strings, creates multiple rows from a single JSON document similar to MongoDB's $unwind
 - `unwindBlank` - Boolean, unwind using blank values instead of repeating data.
 - `flatten` - Boolean, flattens nested JSON using [flat]. Defaults to `false`.
+- `flattenSeparator` - String, separator to use between nested JSON keys when `flatten` option enabled. Defaults to `.` if not specified.
 - `defaultValue` - String, default value to use when missing data. Defaults to `<empty>` if not specified. (Overridden by `fields[].default`)
 - `quote` - String, quote around cell values and column names. Defaults to `"` if not specified.
 - `doubleQuote` - String, the value to replace double quote in strings. Defaults to 2x`quotes` (for example `""`) if not specified.

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -24,14 +24,15 @@ program
   .option('-c, --fields-config <path>', 'Specify a file with a fields configuration as a JSON array.')
   .option('-u, --unwind <paths>', 'Creates multiple rows from a single JSON document similar to MongoDB unwind.')
   .option('-B, --unwind-blank', 'When unwinding, blank out instead of repeating data.')
-  .option('-F, --flatten', 'Flatten nested objects')
+  .option('-F, --flatten', 'Flatten nested objects.')
+  .option('-S, --flatten-separator <separator>', 'Flattened keys separator.')
   .option('-v, --default-value [defaultValue]', 'Specify a default value other than empty string.')
   .option('-q, --quote [value]', 'Specify an alternate quote value.')
-  .option('-Q, --double-quote [value]', 'Specify a value to replace double quote in strings')
+  .option('-Q, --double-quote [value]', 'Specify a value to replace double quote in strings.')
   .option('-d, --delimiter [delimiter]', 'Specify a delimiter other than the default comma to use.')
   .option('-e, --eol [value]', 'Specify an End-of-Line value for separating rows.')
-  .option('-E, --excel-strings','Converts string data into normalized Excel style data')
-  .option('-H, --no-header', 'Disable the column name header')
+  .option('-E, --excel-strings','Converts string data into normalized Excel style data.')
+  .option('-H, --no-header', 'Disable the column name header.')
   .option('-a, --include-empty-rows', 'Includes empty rows in the resulting CSV output.')
   .option('-b, --with-bom', 'Includes BOM character at the beginning of the csv.')
   .option('-p, --pretty', 'Use only when printing to console. Logs output in pretty tables.')
@@ -156,6 +157,7 @@ Promise.resolve()
       unwind: program.unwind ? program.unwind.split(',') : [],
       unwindBlank: program.unwindBlank,
       flatten: program.flatten,
+      flattenSeparator: program.flattenSeparator,
       defaultValue: program.defaultValue,
       quote: program.quote,
       doubleQuote: program.doubleQuote,

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -22,6 +22,7 @@ class JSON2CSVBase {
       ? (processedOpts.unwind ? [processedOpts.unwind] : [])
       : processedOpts.unwind
     processedOpts.delimiter = processedOpts.delimiter || ',';
+    processedOpts.flattenSeparator = processedOpts.flattenSeparator || '.';
     processedOpts.eol = processedOpts.eol || os.EOL;
     processedOpts.quote = typeof processedOpts.quote === 'string'
       ? opts.quote
@@ -63,7 +64,7 @@ class JSON2CSVBase {
       : [row];
 
     if (this.opts.flatten) {
-      return processedRow.map(this.flatten);
+      return processedRow.map(this.flatten());
     }
 
     return processedRow;
@@ -211,31 +212,35 @@ class JSON2CSVBase {
    * @param {Object} dataRow Original JSON object
    * @returns {Object} Flattened object
    */
-  flatten(dataRow) {
-    function step (obj, flatDataRow, currentPath) {
-      Object.keys(obj).forEach((key) => {
-        const value = obj[key];
+  flatten() {
+    return (dataRow) => {
+      const separator = this.opts.flattenSeparator;
 
-        const newPath = currentPath
-          ? `${currentPath}.${key}`
-          : key;
+      function step (obj, flatDataRow, currentPath) {
+        Object.keys(obj).forEach((key) => {
+          const value = obj[key];
 
-        if (typeof value !== 'object'
-          || value === null
-          || Array.isArray(value)
-          || Object.prototype.toString.call(value.toJSON) === '[object Function]'
-          || !Object.keys(value).length) {
-          flatDataRow[newPath] = value;
-          return;
-        }
+          const newPath = currentPath
+            ? `${currentPath}${separator}${key}`
+            : key;
 
-        step(value, flatDataRow, newPath);
-      });
+          if (typeof value !== 'object'
+            || value === null
+            || Array.isArray(value)
+            || Object.prototype.toString.call(value.toJSON) === '[object Function]'
+            || !Object.keys(value).length) {
+            flatDataRow[newPath] = value;
+            return;
+          }
 
-      return flatDataRow;
+          step(value, flatDataRow, newPath);
+        });
+
+        return flatDataRow;
+      }
+
+      return step(dataRow, {});
     }
-
-    return step(dataRow, {});
   }
 
   /**

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -209,8 +209,7 @@ class JSON2CSVBase {
   /**
    * Performs the flattening of a data row recursively
    *
-   * @param {Object} dataRow Original JSON object
-   * @returns {Object} Flattened object
+   * @returns {Function} Function that receives dataRow as input and outputs flattened object 
    */
   flatten() {
     return (dataRow) => {

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -453,6 +453,25 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       .on('error', err => t.notOk(true, err.message));
   });
 
+  testRunner.add('should support custom flatten separator', (t) => {
+    const opts = {
+      flatten: true,
+      flattenSeparator: '__',
+    };
+
+    const transform = new Json2csvTransform(opts);
+    const processor = jsonFixtures.deepJSON().pipe(transform);
+
+    let csv = '';
+    processor
+      .on('data', chunk => (csv += chunk.toString()))
+      .on('end', () => {
+        t.equal(csv, csvFixtures.flattenedCustomSeparatorDeepJSON);
+        t.end();
+      })
+      .on('error', err => t.notOk(true, err.message));
+  });
+
   testRunner.add('should unwind and flatten an object in the right order', (t) => {
     const opts = {
       unwind: ['items'],

--- a/test/fixtures/csv/flattenedCustomSeparatorDeepJSON.csv
+++ b/test/fixtures/csv/flattenedCustomSeparatorDeepJSON.csv
@@ -1,0 +1,2 @@
+"field1__embeddedField1","field1__embeddedField2"
+"embeddedValue1","embeddedValue2"


### PR DESCRIPTION
Hi @zemirco,

First of all - thank you very much for this great library.

I've added `flattenSeparator` option. Basically what it does is allowing us to use `flatten: true` not only to produce header values like `Key1.Key2` but `Key1__Key2` also.

Here few things I had to change while implementing this feature:

- In `lib/JSON2CSVBase.js` we had `JSON2CSVBase#flatten(dataRow)` method that was implicitly called while processing rows. The bad thing about it - we couldn't access JSON2CSVBase instance (`this`) from the `#flatten()` method. I had to return another function from it, that actually handles the logic. As an alternative, we can move the flatten logic outside the class at all. What do you think?

- In `README.md` I added documentation and added some dots to the end of options definitions (48-69 lines). Sorry that it shows everything as changed, I had to indent all lines to fit newly created option.

Thank you very much,
Looking forward to your comments and approval if everything is ok.