### PR TITLE
Clean up the flattening separator feature

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -64,7 +64,7 @@ class JSON2CSVBase {
       : [row];
 
     if (this.opts.flatten) {
-      return processedRow.map(this.flatten());
+      return processedRow.map(row => this.flatten(row, this.opts.flattenSeparator));
     }
 
     return processedRow;
@@ -209,37 +209,35 @@ class JSON2CSVBase {
   /**
    * Performs the flattening of a data row recursively
    *
-   * @returns {Function} Function that receives dataRow as input and outputs flattened object 
+   * @param {Object} dataRow Original JSON object
+   * @param {String} separator Separator to be used as the flattened field name
+   * @returns {Object} Flattened object
    */
-  flatten() {
-    return (dataRow) => {
-      const separator = this.opts.flattenSeparator;
+  flatten(dataRow, separator) {
+    function step (obj, flatDataRow, currentPath) {
+      Object.keys(obj).forEach((key) => {
+        const value = obj[key];
 
-      function step (obj, flatDataRow, currentPath) {
-        Object.keys(obj).forEach((key) => {
-          const value = obj[key];
+        const newPath = currentPath
+          ? `${currentPath}${separator}${key}`
+          : key;
 
-          const newPath = currentPath
-            ? `${currentPath}${separator}${key}`
-            : key;
+        if (typeof value !== 'object'
+          || value === null
+          || Array.isArray(value)
+          || Object.prototype.toString.call(value.toJSON) === '[object Function]'
+          || !Object.keys(value).length) {
+          flatDataRow[newPath] = value;
+          return;
+        }
 
-          if (typeof value !== 'object'
-            || value === null
-            || Array.isArray(value)
-            || Object.prototype.toString.call(value.toJSON) === '[object Function]'
-            || !Object.keys(value).length) {
-            flatDataRow[newPath] = value;
-            return;
-          }
+        step(value, flatDataRow, newPath);
+      });
 
-          step(value, flatDataRow, newPath);
-        });
-
-        return flatDataRow;
-      }
-
-      return step(dataRow, {});
+      return flatDataRow;
     }
+
+    return step(dataRow, {});
   }
 
   /**

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -313,13 +313,24 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     });
   });
 
-  testRunner.add('should support flattenning deep JSON', (t) => {
+  testRunner.add('should support flattening deep JSON', (t) => {
     const opts = ' --flatten';
 
     child_process.exec(cli + '-i ' + getFixturePath('/json/deepJSON.json') + opts, (err, stdout, stderr) => {
       t.notOk(stderr);
       const csv = stdout;
       t.equal(csv, csvFixtures.flattenedDeepJSON);
+      t.end();
+    });
+  });
+
+  testRunner.add('should support custom flatten separator', (t) => {
+    const opts = ' --flatten --flatten-separator __';
+
+    child_process.exec(cli + '-i ' + getFixturePath('/json/deepJSON.json') + opts, (err, stdout, stderr) => {
+      t.notOk(stderr);
+      const csv = stdout;
+      t.equal(csv, csvFixtures.flattenedCustomSeparatorDeepJSON);
       t.end();
     });
   });

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -290,7 +290,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
   });
 
 
-  testRunner.add('should support flattenning deep JSON', (t) => {
+  testRunner.add('should support flattening deep JSON', (t) => {
     const opts = {
       flatten: true
     };
@@ -302,7 +302,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.end();
   });
 
-  testRunner.add('should support flattenning JSON with toJSON', (t) => {
+  testRunner.add('should support flattening JSON with toJSON', (t) => {
     const opts = {
       flatten: true
     };
@@ -311,6 +311,19 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     const csv = parser.parse(jsonFixtures.flattenToJSON);
 
     t.equal(csv, csvFixtures.flattenToJSON);
+    t.end();
+  });
+
+  testRunner.add('should support custom flatten separator', (t) => {
+    const opts = {
+      flatten: true,
+      flattenSeparator: '__',
+    };
+
+    const parser = new Json2csvParser(opts);
+    const csv = parser.parse(jsonFixtures.deepJSON);
+
+    t.equal(csv, csvFixtures.flattenedCustomSeparatorDeepJSON);
     t.end();
   });
 

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -435,7 +435,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       .on('error', err => t.notOk(true, err.message));
   });
 
-  testRunner.add('should support flattenning deep JSON', (t) => {
+  testRunner.add('should support flattening deep JSON', (t) => {
     const opts = {
       flatten: true
     };


### PR DESCRIPTION
Clean up a bit after #314.

* Improves function signature bringing it back to the original approach.
* Add missing tests.
* Fix a typo in the old tests names.

Also, next time we merge a change that modifies the functions signatures, please create a task so I update the TypeScript types.