### PR TITLE
Optimize performance around the usage of fields

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -38,18 +38,62 @@ class JSON2CSVBase {
   }
 
   /**
+   * Check and normalize the fields configuration.
+   *
+   * @param {(string|object)[]} fields Fields configuration provided by the user
+   * or inferred from the data
+   * @returns {object[]} preprocessed FieldsInfo array
+   */
+  preprocessFieldsInfo(fields) {
+    return fields.map((fieldInfo) => {
+      if (typeof fieldInfo === 'string') {
+        return {
+          label: fieldInfo,
+          value: row => lodashGet(row, fieldInfo, this.opts.defaultValue),
+          stringify: true,
+        };
+      }
+
+      if (typeof fieldInfo === 'object') {
+        const defaultValue = 'default' in fieldInfo
+          ? fieldInfo.default
+          : this.opts.defaultValue;
+
+        if (typeof fieldInfo.value === 'string') {
+          return {
+            label: fieldInfo.label || fieldInfo.value,
+            value: row => lodashGet(row, fieldInfo.value, defaultValue),
+            stringify: fieldInfo.stringify !== undefined ? fieldInfo.stringify : true,
+          };
+        }
+
+        if (typeof fieldInfo.value === 'function') {
+          return {
+            label: fieldInfo.label || fieldInfo.value,
+            value: row => {
+              const field = { label: this.label, default: defaultValue };
+              const value = fieldInfo.value(row, field);
+              return (value === null || value === undefined)
+                ? defaultValue
+                : value;
+            },
+            stringify: fieldInfo.stringify !== undefined ? fieldInfo.stringify : true,
+          }
+        }
+      }
+
+      throw new Error('Invalid field info option. ' + JSON.stringify(fieldInfo));
+    });
+  }
+
+  /**
    * Create the title row with all the provided fields as column headings
    *
    * @returns {String} titles as a string
    */
   getHeader() {
     return this.opts.fields
-      .map(field =>
-        (typeof field === 'string')
-          ? field
-          : (field.label || field.value)
-      )
-      .map(header => this.processValue(header, true))
+      .map(fieldInfo => this.processValue(fieldInfo.label, true))
       .join(this.opts.delimiter);
   }
 
@@ -92,49 +136,11 @@ class JSON2CSVBase {
    * Create the content of a specfic CSV row cell
    *
    * @param {Object} row JSON object representing the  CSV row that the cell belongs to
-   * @param {Object} fieldInfo Details of the field to process to be a CSV cell
+   * @param {FieldInfo} fieldInfo Details of the field to process to be a CSV cell
    * @returns {String} CSV string (cell)
    */
   processCell(row, fieldInfo) {
-    const stringify = typeof fieldInfo === 'object' && fieldInfo.stringify !== undefined
-      ? fieldInfo.stringify
-      : true;
-
-    return this.processValue(this.getValue(row, fieldInfo), stringify);
-  }
-
-  /**
-   * Create the content of a specfic CSV row cell
-   *
-   * @param {Object} row JSON object representing the  CSV row that the cell belongs to
-   * @param {Object} fieldInfo Details of the field to process to be a CSV cell
-   * @returns {Any} Field value
-   */
-  getValue(row, fieldInfo) {
-    const defaultValue = typeof fieldInfo === 'object' && 'default' in fieldInfo
-      ? fieldInfo.default
-      : this.opts.defaultValue;
-
-    let value;
-    if (fieldInfo) {
-      if (typeof fieldInfo === 'string') {
-        value = lodashGet(row, fieldInfo, defaultValue);
-      } else if (typeof fieldInfo === 'object') {
-        if (typeof fieldInfo.value === 'string') {
-          value = lodashGet(row, fieldInfo.value, defaultValue);
-        } else if (typeof fieldInfo.value === 'function') {
-          const field = {
-            label: fieldInfo.label,
-            default: fieldInfo.default
-          };
-          value = fieldInfo.value(row, field);
-        }
-      }
-    }
-
-    return (value === null || value === undefined)
-      ? defaultValue
-      : value;
+    return this.processValue(fieldInfo.value(row), fieldInfo.stringify);
   }
 
   /**

--- a/lib/JSON2CSVParser.js
+++ b/lib/JSON2CSVParser.js
@@ -21,6 +21,8 @@ class JSON2CSVParser extends JSON2CSVBase {
         .filter((field, pos, arr) => arr.indexOf(field) == pos);
     }
 
+    this.opts.fields = this.preprocessFieldsInfo(this.opts.fields);
+
     const header = this.opts.header ? this.getHeader() : '';
     const rows = this.processData(processedData);
     const csv = (this.opts.withBOM ? '\ufeff' : '')

--- a/lib/JSON2CSVTransform.js
+++ b/lib/JSON2CSVTransform.js
@@ -28,6 +28,7 @@ class JSON2CSVTransform extends Transform {
     }
 
     if (this.opts.fields) {
+      this.opts.fields = this.preprocessFieldsInfo(this.opts.fields);
       this.pushHeader();
     }
 
@@ -150,7 +151,7 @@ class JSON2CSVTransform extends Transform {
    */
   pushHeader() {
     if (this.opts.header) {
-      const header = this.getHeader(this.opts);
+      const header = this.getHeader();
       this.emit('header', header);
       this.push(header);
       this._hasWritten = true;
@@ -166,7 +167,7 @@ class JSON2CSVTransform extends Transform {
     const processedData = this.preprocessRow(data);
     
     if (!this._hasWritten) {
-      this.opts.fields = this.opts.fields || Object.keys(processedData[0]);
+      this.opts.fields = this.opts.fields || this.preprocessFieldsInfo(Object.keys(processedData[0]));
       this.pushHeader();
     }
 

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -198,7 +198,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     });
   });
 
-  testRunner.add('should output keep fields order', (t) => {
+  testRunner.add('should output fields in the order provided', (t) => {
     const opts = ' --fields price,carModel';
 
     child_process.exec(cli + '-i ' + getFixturePath('/json/default.json') + opts, (err, stdout, stderr) => {

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -140,7 +140,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.end();
   });
 
-  testRunner.add('should output keep fields order', (t) => {
+  testRunner.add('should output fields in the order provided', (t) => {
     const opts = {
       fields: ['price', 'carModel']
     };
@@ -179,6 +179,41 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     const csv = parser.parse(jsonFixtures.default);
     
     t.equal(csv, csvFixtures.fieldNames);
+    t.end();
+  });
+
+  testRunner.add('should error on invalid \'fields\' property', (t) => {
+    const opts = {
+      fields: [ { value: 'price', stringify: true }, () => {} ]
+    };
+
+    try {
+      const parser = new Json2csvParser(opts);
+      parser.parse(jsonFixtures.default);
+
+      t.notOk(true);
+    } catch(error) {
+      t.equal(error.message, 'Invalid field info option. ' + JSON.stringify(opts.fields[1]));
+    }
+    t.end();
+  });
+
+  testRunner.add('should error on invalid \'fields.value\' property', (t) => {
+    const opts = {
+      fields: [
+        { value: row => row.price, stringify: true }, 
+        { label: 'Price USD', value: [] }
+      ]
+    };
+
+    try {
+      const parser = new Json2csvParser(opts);
+      parser.parse(jsonFixtures.default);
+
+      t.notOk(true);
+    } catch(error) {
+      t.equal(error.message, 'Invalid field info option. ' + JSON.stringify(opts.fields[1]));
+    }
     t.end();
   });
 

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -220,7 +220,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       .on('error', err => t.notOk(true, err.message));
   });
 
-  testRunner.add('should output keep fields order', (t) => {
+  testRunner.add('should output fields in the order provided', (t) => {
     const opts = {
       fields: ['price', 'carModel']
     };
@@ -278,6 +278,43 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
         t.end();
       })
       .on('error', err => t.notOk(true, err.message));
+  });
+
+
+
+  testRunner.add('should error on invalid \'fields\' property', (t) => {
+    const opts = {
+      fields: [ { value: 'price', stringify: true }, () => {} ]
+    };
+
+    try {
+      const transform = new Json2csvTransform(opts);
+      jsonFixtures.default().pipe(transform);
+
+      t.notOk(true);
+    } catch(error) {
+      t.equal(error.message, 'Invalid field info option. ' + JSON.stringify(opts.fields[1]));
+    }
+    t.end();
+  });
+
+  testRunner.add('should error on invalid \'fields.value\' property', (t) => {
+    const opts = {
+      fields: [
+        { value: row => row.price, stringify: true }, 
+        { label: 'Price USD', value: [] }
+      ]
+    };
+
+    try {
+      const transform = new Json2csvTransform(opts);
+      jsonFixtures.default().pipe(transform);
+
+      t.notOk(true);
+    } catch(error) {
+      t.equal(error.message, 'Invalid field info option. ' + JSON.stringify(opts.fields[1]));
+    }
+    t.end();
   });
 
   testRunner.add('should support nested properties selectors', (t) => {

--- a/test/fixtures/csv/defaultValueEmpty.csv
+++ b/test/fixtures/csv/defaultValueEmpty.csv
@@ -1,5 +1,5 @@
 "carModel","price"
 "Audi",0
 "BMW",15000
-"Mercedes",""
+"Mercedes",
 "Porsche",30000


### PR DESCRIPTION
We were running all the logic around fields, labels, etc. on each row.
With this change, it is run only once at the beginning.

It also corrects a small bug that I found were an empty number was set as `""`.