### PR TITLE
Remove lodash.clonedeep dependency

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -3,7 +3,6 @@
 const os = require('os');
 const lodashGet = require('lodash.get');
 const lodashSet = require('lodash.set');
-const lodashCloneDeep = require('lodash.clonedeep');
 
 class JSON2CSVBase {
   constructor(opts) {
@@ -255,9 +254,14 @@ class JSON2CSVBase {
   */
   unwindData(dataRow, unwindPaths) {
     const unwind = (rows, unwindPath) => {
-      const clone = unwindPath.indexOf('.') !== -1
-        ? o => lodashCloneDeep(o)
-        : o => Object.assign({}, o);
+      const pathAndField = unwindPath.split(/\.(?=[^.]+$)/);
+      const setUnwoundValue = pathAndField.length === 2
+        ? (() => {
+          const parentPath = pathAndField[0];
+          const unwindField = pathAndField[1];
+          return (row, value) => lodashSet(Object.assign({}, row), parentPath, Object.assign({}, lodashGet(row, parentPath), { [unwindField]: value }));
+        })()
+        : (row, value) => Object.assign({}, row, { [unwindPath]: value });
 
       return rows
         .map(row => {
@@ -268,15 +272,15 @@ class JSON2CSVBase {
           }
 
           if (!unwindArray.length) {
-            return lodashSet(clone(row), unwindPath, undefined);
+            return setUnwoundValue(row, undefined);
           }
 
           return unwindArray.map((unwindRow, index) => {
             const clonedRow = (this.opts.unwindBlank && index > 0)
               ? {}
-              : clone(row);
+              : row;
 
-            return lodashSet(clonedRow, unwindPath, unwindRow);
+            return setUnwoundValue(clonedRow, unwindRow);
           });
         })
         .reduce((a, e) => a.concat(e), []);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,12 +4970,6 @@
         }
       }
     },
-    "git-update-ghpages": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/git-update-ghpages/-/git-update-ghpages-1.3.0.tgz",
-      "integrity": "sha1-TP8lTiH2TVo6KYZaAfNv0WTYyiU=",
-      "dev": true
-    },
     "gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
@@ -6404,11 +6398,6 @@
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.defaults": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "commander": "^2.15.1",
     "jsonparse": "^1.3.1",
-    "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
   },


### PR DESCRIPTION
This should resolve #333

Since lodash modules don't seem to have a reliable release cycle and we don't really need clonedeep. Let's just get rid of it altogether.

This should also have a good impact on performance since now we only do shallow clones where needed instead of lodash.deepclone (which is famously solid and infamously slow).