### PR TITLE
Remove invalid reference to flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The programatic APIs take a configuration object very equivalent to the CLI opti
 - `ndjson` - Only effective on the streaming API. Indicates that data coming through the stream is NDJSON.
 - `unwind` - Array of Strings, creates multiple rows from a single JSON document similar to MongoDB's $unwind
 - `unwindBlank` - Boolean, unwind using blank values instead of repeating data.
-- `flatten` - Boolean, flattens nested JSON using [flat]. Defaults to `false`.
+- `flatten` - Boolean, flattens nested objects. Defaults to `false`.
 - `flattenSeparator` - String, separator to use between nested JSON keys when `flatten` option enabled. Defaults to `.` if not specified.
 - `defaultValue` - String, default value to use when missing data. Defaults to `<empty>` if not specified. (Overridden by `fields[].default`)
 - `quote` - String, quote around cell values and column names. Defaults to `"` if not specified.


### PR DESCRIPTION
We haven't used flat for ages.

This was just a wrong reference.