### PR TITLE
fix: transform in object mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ The stream API can also work on object mode. This is useful when you have an inp
     const transformOpts = { objectMode: true };
 
     const json2csv = new Json2csvTransform(opts, transformOpts);
-    const processor = input.pipe(transform).pipe(output);
+    const processor = input.pipe(json2csv).pipe(output);
 ```
 
 ### Javascript module examples


### PR DESCRIPTION
Hi there,

There seemed to be an issue with the Transform stream on `objectMode:true`.
Aside from the typo (`transform` instead of `json2csv`), example didn't work for me.

```js
    const input = new Readable({ objectMode: true });
    input._read = () => {};
    // myObjectEmitter is just a fake example representing anything that emit objects.
    myObjectEmitter.on('object', obj => input.push(obj));
    // Pushing a null close the stream
    myObjectEmitter.end(()) => input.push(null));

    const opts = {};
    const transformOpts = { objectMode: true };

    const json2csv = new Json2csvTransform(opts, transformOpts);
    const processor = input.pipe(json2csv).pipe(output);
```

Hence, this PR tries adds a check in the `_transform` function to pass `chunk` directly to `pushLine` instead of trying to parse the object as a JSON string.

```
--- a/lib/JSON2CSVTransform.js
+++ b/lib/JSON2CSVTransform.js
@@ -153,7 +153,13 @@ class JSON2CSVTransform extends Transform {
    * @param {Function} done Called when the proceesing of the supplied chunk is done
    */
   _transform(chunk, encoding, done) {
-    this.parser.write(chunk);
+    // on objectMode:true, chunk doesn't need to get parsed
+    // push it directly to processor
+    if (this.opts.objectMode) {
+      this.pushLine(chunk);
+    } else {
+      this.parser.write(chunk);
+    }
     done();
   }
````

LMKWYT,
Cheers.