### PR TITLE
Add support for JSON and Streams on the parseAsync method

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ asyncParser.fromInput(input).toOutput(output).promise()
   .catch(err => console.error(err));;
 ```
 
-you can also use the convenience method `parseAsync` which returns a promise.
+you can also use the convenience method `parseAsync` which accept both JSON arrays/objects and readable streams and returns a promise.
 
 ```js
 const { parseAsync } = require('json2csv');

--- a/lib/json2csv.js
+++ b/lib/json2csv.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Readable } = require('stream');
 const JSON2CSVParser = require('./JSON2CSVParser');
 const JSON2CSVAsyncParser = require('./JSON2CSVAsyncParser');
 const JSON2CSVTransform = require('./JSON2CSVTransform');
@@ -11,11 +12,22 @@ module.exports.Transform = JSON2CSVTransform;
 // Convenience method to keep the API similar to version 3.X
 module.exports.parse = (data, opts) => new JSON2CSVParser(opts).parse(data);
 module.exports.parseAsync = (data, opts, transformOpts) => {
+  if (!(data instanceof Readable)) {
+    transformOpts = Object.assign({}, transformOpts, { objectMode: true });
+  }
+
   const asyncParser = new JSON2CSVAsyncParser(opts, transformOpts);
   const promise = asyncParser.promise();
 
-  data.forEach(item => asyncParser.input.push(item));
-  asyncParser.input.push(null);
+  if (Array.isArray(data)) {
+    data.forEach(item => asyncParser.input.push(item));
+    asyncParser.input.push(null);
+  } else if (data instanceof Readable) {
+    asyncParser.fromInput(data);
+  } else {
+    asyncParser.input.push(data);
+    asyncParser.input.push(null);
+  }
 
   return promise;
 };

--- a/test/JSON2CSVAsyncParser.js
+++ b/test/JSON2CSVAsyncParser.js
@@ -4,13 +4,42 @@ const { Readable, Transform, Writable } = require('stream');
 const { AsyncParser, parseAsync } = require('../lib/json2csv');
 
 module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) => {
-  testRunner.add('should parse json to csv, infer the fields automatically and not modify the opts passed using parseAsync method', (t) => {
+  testRunner.add('should parse in-memory json array to csv, infer the fields automatically and not modify the opts passed using parseAsync method', (t) => {
     const opts = {
       fields: ['carModel', 'price', 'color', 'transmission']
     };
-    const transformOpts = { objectMode: true };
 
-    parseAsync(inMemoryJsonFixtures.default, opts, transformOpts)
+    parseAsync(inMemoryJsonFixtures.default, opts)
+      .then((csv) => {
+        t.ok(typeof csv === 'string');
+        t.equal(csv, csvFixtures.default);
+        t.deepEqual(opts, { fields: ['carModel', 'price', 'color', 'transmission'] });
+      })
+      .catch(err => t.notOk(true, err.message))
+      .then(() => t.end());
+  });
+  
+  testRunner.add('should parse in-memory json object to csv, infer the fields automatically and not modify the opts passed using parseAsync method', (t) => {
+    const opts = {
+      fields: ['carModel', 'price', 'color', 'transmission']
+    };
+
+    parseAsync({ "carModel": "Audi",      "price": 0,  "color": "blue" }, opts)
+      .then((csv) => {
+        t.ok(typeof csv === 'string');
+        t.equal(csv, '"carModel","price","color","transmission"\n"Audi",0,"blue",');
+        t.deepEqual(opts, { fields: ['carModel', 'price', 'color', 'transmission'] });
+      })
+      .catch(err => t.notOk(true, err.message))
+      .then(() => t.end());
+  });
+
+  testRunner.add('should parse streaming json to csv, infer the fields automatically and not modify the opts passed using parseAsync method', (t) => {
+    const opts = {
+      fields: ['carModel', 'price', 'color', 'transmission']
+    };
+
+    parseAsync(jsonFixtures.default(), opts)
       .then((csv) => {
         t.ok(typeof csv === 'string');
         t.equal(csv, csvFixtures.default);


### PR DESCRIPTION
I realized that the asyncParse method only works for JSON and only providing the `objectMode` flag.

With this change, it accepts both JSON and streams and intelligently selects the stream mode.