### PR TITLE
Performance improvements.

### DIFF
--- a/lib/JSON2CSVAsyncParser.js
+++ b/lib/JSON2CSVAsyncParser.js
@@ -2,6 +2,7 @@
 
 const { Transform } = require('stream');
 const JSON2CSVTransform = require('./JSON2CSVTransform');
+const { fastJoin } = require('./utils');
 
 class JSON2CSVAsyncParser {
   constructor(opts, transformOpts) {
@@ -40,10 +41,10 @@ class JSON2CSVAsyncParser {
 
   promise() {
     return new Promise((resolve, reject) => {
-      let csv = '';
+      let csvBuffer = [];
       this.processor
-        .on('data', chunk => (csv += chunk.toString()))
-        .on('finish', () => resolve(csv))
+        .on('data', chunk => csvBuffer.push(chunk.toString()))
+        .on('finish', () => resolve(fastJoin(csvBuffer, '')))
         .on('error', err => reject(err));
     });
   }

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -2,7 +2,7 @@
 
 const os = require('os');
 const lodashGet = require('lodash.get');
-const { setProp, flattenReducer } = require('./utils');
+const { getProp, setProp, fastJoin, flattenReducer } = require('./utils');
 
 class JSON2CSVBase {
   constructor(opts) {
@@ -29,7 +29,7 @@ class JSON2CSVBase {
       : '"';
     processedOpts.doubleQuote = typeof processedOpts.doubleQuote === 'string'
       ? processedOpts.doubleQuote
-      : Array(3).join(processedOpts.quote);
+      : processedOpts.quote + processedOpts.quote;
     processedOpts.header = processedOpts.header !== false;
     processedOpts.includeEmptyRows = processedOpts.includeEmptyRows || false;
     processedOpts.withBOM = processedOpts.withBOM || false;
@@ -49,7 +49,9 @@ class JSON2CSVBase {
       if (typeof fieldInfo === 'string') {
         return {
           label: fieldInfo,
-          value: row => lodashGet(row, fieldInfo, this.opts.defaultValue),
+          value: (fieldInfo.includes('.') || fieldInfo.includes('['))
+            ? row => lodashGet(row, fieldInfo, this.opts.defaultValue)
+            : row => getProp(row, fieldInfo, this.opts.defaultValue),
           stringify: true,
         };
       }
@@ -62,7 +64,9 @@ class JSON2CSVBase {
         if (typeof fieldInfo.value === 'string') {
           return {
             label: fieldInfo.label || fieldInfo.value,
-            value: row => lodashGet(row, fieldInfo.value, defaultValue),
+            value: (fieldInfo.value.includes('.') || fieldInfo.value.includes('['))
+              ? row => lodashGet(row, fieldInfo.value, defaultValue)
+              : row => getProp(row, fieldInfo.value, defaultValue),
             stringify: fieldInfo.stringify !== undefined ? fieldInfo.stringify : true,
           };
         }
@@ -93,9 +97,10 @@ class JSON2CSVBase {
    * @returns {String} titles as a string
    */
   getHeader() {
-    return this.opts.fields
-      .map(fieldInfo => this.processValue(fieldInfo.label, true))
-      .join(this.opts.delimiter);
+    return fastJoin(
+      this.opts.fields.map(fieldInfo => this.processValue(fieldInfo.label, true)),
+      this.opts.delimiter
+    );
   }
 
   memoizePreprocessRow() {
@@ -139,15 +144,20 @@ class JSON2CSVBase {
    * @returns {String} CSV string (row)
    */
   processRow(row) {
-    if (!row
-        || (Object.getOwnPropertyNames(row).length === 0
-          && !this.opts.includeEmptyRows)) {
+    if (!row) {
       return undefined;
     }
 
-    return this.opts.fields
-      .map(fieldInfo => this.processCell(row, fieldInfo))
-      .join(this.opts.delimiter);
+    const processedRow = this.opts.fields.map(fieldInfo => this.processCell(row, fieldInfo));
+
+    if (!this.opts.includeEmptyRows && processedRow.every(field => field === undefined)) {
+      return undefined;
+    }
+
+    return fastJoin(
+      processedRow,
+      this.opts.delimiter
+    );
   }
 
   /**
@@ -173,61 +183,39 @@ class JSON2CSVBase {
       return undefined;
     }
 
-    const isValueString = typeof value === 'string';
-    if (isValueString) {
-      value = value
-        .replace(/\n/g, '\u2028')
-        .replace(/\r/g, '\u2029')
-        .replace(/\t/g, '\u21E5');
+    const valueType = typeof value;
+    if (valueType !== 'boolean' && valueType !== 'number' && valueType !== 'string') {
+      value = JSON.stringify(value);
+
+      if (value === undefined) {
+        return undefined;
+      }
+
+      if (value[0] === '"') {
+        value = value.replace(/^"(.+)"$/,'$1');
+      }
     }
 
-    //JSON.stringify('\\') results in a string with two backslash
-    //characters in it. I.e. '\\\\'.
-    let stringifiedValue = (stringify
-      ? JSON.stringify(value)
-      : value);
+    if (typeof value === 'string') {
+      if(value.includes(this.opts.quote)) {
+        value = value.replace(new RegExp(this.opts.quote, 'g'), this.opts.doubleQuote);
+      }
 
-    if (typeof value === 'object' && !/^".*"$/.test(stringifiedValue)) {
-      // Stringify object that are not stringified to a
-      // JSON string (like Date) to escape commas, quotes, etc.
-      stringifiedValue = JSON.stringify(stringifiedValue);
+      // This should probably be remove together with the whole strignify option
+      if (stringify) {
+        value = `${this.opts.quote}${value}${this.opts.quote}`;
+      } else {
+        value = value
+          .replace(new RegExp(`^${this.opts.doubleQuote}`), this.opts.quote)
+          .replace(new RegExp(`${this.opts.doubleQuote}$`), this.opts.quote);
+      }
+
+      if (this.opts.excelStrings) {
+        value = `"="${value}""`;
+      }
     }
 
-    if (stringifiedValue === undefined) {
-      return undefined;
-    }
-
-    if (isValueString) {
-      stringifiedValue = stringifiedValue
-        .replace(/\u2028/g, '\n')
-        .replace(/\u2029/g, '\r')
-        .replace(/\u21E5/g, '\t');
-    }
-
-    if (this.opts.quote === '"') {
-      // Replace automatically escaped single quotes by doubleQuotes
-      stringifiedValue = stringifiedValue
-        .replace(/\\"(?!$)/g, this.opts.doubleQuote);
-    } else {
-      // Unescape double quotes ('"')
-      // Replace single quote with double quote
-      // Replace wrapping quotes
-      stringifiedValue = stringifiedValue
-        .replace(/\\"(?!$)/g, '"')
-        .replace(new RegExp(this.opts.quote, 'g'), this.opts.doubleQuote)
-        .replace(/^"/, this.opts.quote)
-        .replace(/"$/, this.opts.quote);
-    }
-
-    // Remove double backslashes
-    stringifiedValue = stringifiedValue
-      .replace(/\\\\/g, '\\');
-
-    if (this.opts.excelStrings && typeof value === 'string') {
-      stringifiedValue = '"="' + stringifiedValue + '""';
-    }
-
-    return stringifiedValue;
+    return value;
   }
 
   /**

--- a/lib/JSON2CSVParser.js
+++ b/lib/JSON2CSVParser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const JSON2CSVBase = require('./JSON2CSVBase');
-const { flattenReducer } = require('./utils');
+const { fastJoin, flattenReducer } = require('./utils');
 
 class JSON2CSVParser extends JSON2CSVBase {
   constructor(opts) {
@@ -73,10 +73,10 @@ class JSON2CSVParser extends JSON2CSVBase {
    * @returns {String} CSV string (body)
    */
   processData(data) {
-    return data
-      .map(row => this.processRow(row))
-      .filter(row => row) // Filter empty rows
-      .join(this.opts.eol);
+    return fastJoin(
+      data.map(row => this.processRow(row)).filter(row => row), // Filter empty rows
+      this.opts.eol
+    );
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,9 @@
 'use strict';
 
+function getProp(obj, path, defaultValue) {
+  return obj[path] === undefined ? defaultValue : obj[path];
+}
+
 function setProp(obj, path, value) {
   const pathArray = Array.isArray(path) ? path : path.split('.');
   const key = pathArray[0];
@@ -18,7 +22,25 @@ function flattenReducer(acc, arr) {
   }
 }
 
+function fastJoin(arr, separator) {
+  let isFirst = true;
+  return arr.reduce((acc, elem) => {
+    if (elem === null || elem === undefined) {
+      elem = '';
+    }
+
+    if (isFirst) {
+      isFirst = false;
+      return `${elem}`;
+    }
+
+    return `${acc}${separator}${elem}`;
+  }, '');
+}
+
 module.exports = {
+  getProp,
   setProp,
+  fastJoin,
   flattenReducer
 };

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -560,8 +560,8 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       const csv = stdout;
       t.equal(csv, [
       '"a string"',
-      '"with a \ndescription\\n and\na new line"',
-      '"with a \r\ndescription and\r\nanother new line"'
+      '"with a \u2028description\\n and\na new line"',
+      '"with a \u2029\u2028description and\r\nanother new line"'
     ].join('\r\n'));
       t.end();
     });

--- a/test/JSON2CSVAsyncParser.js
+++ b/test/JSON2CSVAsyncParser.js
@@ -716,8 +716,8 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
     parser.fromInput(jsonFixtures.escapeEOL()).promise()
       .then(csv => t.equal(csv, [
       '"a string"',
-      '"with a \ndescription\\n and\na new line"',
-      '"with a \r\ndescription and\r\nanother new line"'
+      '"with a \u2028description\\n and\na new line"',
+      '"with a \u2029\u2028description and\r\nanother new line"'
     ].join('\r\n')))
       .catch(err => t.notOk(true, err.message))
       .then(() => t.end());

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -657,8 +657,8 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
 
     t.equal(csv, [
       '"a string"',
-      '"with a \ndescription\\n and\na new line"',
-      '"with a \r\ndescription and\r\nanother new line"'
+      '"with a \u2028description\\n and\na new line"',
+      '"with a \u2029\u2028description and\r\nanother new line"'
     ].join('\r\n'));
     t.end();
   });

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -1081,8 +1081,8 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
       .on('end', () => {
         t.equal(csv, [
       '"a string"',
-      '"with a \ndescription\\n and\na new line"',
-      '"with a \r\ndescription and\r\nanother new line"'
+      '"with a \u2028description\\n and\na new line"',
+      '"with a \u2029\u2028description and\r\nanother new line"'
     ].join('\r\n'));
         t.end();
       })


### PR DESCRIPTION
Some serious performance improvements.

Running Benchmak.js
* on a Macbook Pro 2015 2,2 GHz and 15 GB
* on Node.js 11.9.0
* on a simple repetitive dataset (`const sampleData = Array(100000).fill({ carModel: 'BMW', price: 15000,  color: 'red', transmission: 'manual' });`)
* with all default options

I get this:
```
 > new json2csv.parse x 8.25 ops/sec ±4.51% (25 runs sampled)
 > new json2csv.parseAsync x 6.30 ops/sec ±3.41% (34 runs sampled)
 > local json2csv.Transform x 8.26 ops/sec ±2.86% (43 runs sampled)
 > current json2csv.parse x 2.09 ops/sec ±2.61% (10 runs sampled)
 > current json2csv.parseAsync x 2.05 ops/sec ±3.77% (15 runs sampled)
 > json2csv.Transform x 2.09 ops/sec ±2.17% (15 runs sampled)
 > json-2-csv x 3.41 ops/sec ±1.20% (21 runs sampled)
 > papaparse x 5.68 ops/sec ±6.21% (18 runs sampled)

Fastest is new json2csv.Transform
```

So json2csv gets 4 times faster and goes from the slowest to the fastest library around the block.
The results are similar passing the `fields` options (all of the above just get equally faster), and in safari and edge. However, in chrome json2csv is still not doing too well I need to investigate why.


I'm sure that there is more room for improvement and I still need to test with more advanced options. But this is a good first step.


As side effects:
* We properly preserve unicode new line and tab (before they where converted to `\n` and `\t`)
* Empty lines logic is correct (before it wouldn't work if someone used the `fields` options and has an object with fields but none of which match the given options).