### PR TITLE
Ensure defaultValue is always applied in the case of nulls

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function getProp(obj, path, defaultValue) {
-  return obj[path] === undefined ? defaultValue : obj[path];
+  return (obj[path] === undefined || obj[path] === null) ? defaultValue : obj[path];
 }
 
 function setProp(obj, path, value) {

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -360,7 +360,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
   // Default value
 
   testRunner.add('should output the default value as set in \'defaultValue\'', (t) => {
-    const opts = ' --fields carModel,price --default-value ""';
+    const opts = ' --fields carModel,price --default-value "-"';
 
     child_process.exec(cli + '-i ' + getFixturePath('/json/defaultValueEmpty.json') + opts, (err, stdout, stderr) => {
       t.notOk(stderr); 
@@ -372,7 +372,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
 
   testRunner.add('should override \'options.defaultValue\' with \'field.defaultValue\'', (t) => {
     const opts = ' --fields-config ' + getFixturePath('/fields/overriddenDefaultValue.json')
-      + ' --default-value ""';
+      + ' --default-value "-"';
 
     child_process.exec(cli + '-i ' + getFixturePath('/json/overriddenDefaultValue.json') + opts, (err, stdout, stderr) => {
       t.notOk(stderr);
@@ -384,7 +384,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
 
   testRunner.add('should use \'options.defaultValue\' when no \'field.defaultValue\'', (t) => {
     const opts = ' --fields-config ' + getFixturePath('/fields/overriddenDefaultValue2.js')
-      + ' --default-value ""';
+      + ' --default-value "-"';
 
     child_process.exec(cli + '-i ' + getFixturePath('/json/overriddenDefaultValue.json') + opts, (err, stdout, stderr) => {
       t.notOk(stderr);

--- a/test/JSON2CSVAsyncParser.js
+++ b/test/JSON2CSVAsyncParser.js
@@ -513,7 +513,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
   testRunner.add('should output the default value as set in \'defaultValue\'', (t) => {
     const opts = {
       fields: ['carModel', 'price'],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const parser = new AsyncParser(opts);
@@ -530,7 +530,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
         { value: 'price', default: 1 },
         { value: 'color' }
       ],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const parser = new AsyncParser(opts);
@@ -556,7 +556,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
           value: row => row.color
         }
       ],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const parser = new AsyncParser(opts);

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -413,7 +413,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
   testRunner.add('should output the default value as set in \'defaultValue\'', (t) => {
     const opts = {
       fields: ['carModel', 'price'],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const parser = new Json2csvParser(opts);
@@ -430,7 +430,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
         { value: 'price', default: 1 },
         { value: 'color' }
       ],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const parser = new Json2csvParser(opts);
@@ -456,7 +456,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
           value: row => row.color
         }
       ],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const parser = new Json2csvParser(opts);

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -671,7 +671,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
   testRunner.add('should output the default value as set in \'defaultValue\'', (t) => {
     const opts = {
       fields: ['carModel', 'price'],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const transform = new Json2csvTransform(opts);
@@ -697,7 +697,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
         { value: 'price', default: 1 },
         { value: 'color' }
       ],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const transform = new Json2csvTransform(opts);
@@ -732,7 +732,7 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
           value: row => row.color
         }
       ],
-      defaultValue: ''
+      defaultValue: '-'
     };
 
     const transform = new Json2csvTransform(opts);

--- a/test/fixtures/csv/defaultValueEmpty.csv
+++ b/test/fixtures/csv/defaultValueEmpty.csv
@@ -1,5 +1,5 @@
 "carModel","price"
 "Audi",0
 "BMW",15000
-"Mercedes",
+"Mercedes","-"
 "Porsche",30000

--- a/test/fixtures/csv/overriddenDefaultValue.csv
+++ b/test/fixtures/csv/overriddenDefaultValue.csv
@@ -1,5 +1,5 @@
 "carModel","price","color"
 "Audi",0,"blue"
 "BMW",1,"red"
-"Mercedes",20000,""
+"Mercedes",20000,"-"
 "Porsche",30000,"green"


### PR DESCRIPTION
I noticed that the `default` and `defaultValue` properties are applied from functions in the case of `null` or `undefined` (see https://github.com/zemirco/json2csv/blob/v4/lib/JSON2CSVBase.js#L81), but only `undefined` for simple properties (https://github.com/zemirco/json2csv/blob/v4/lib/utils.js#L4). I also noticed that the tests for `defaultValue` were accidentally relying on the `null` -> `""` transformation, so I updated them to exercise the behavior better.