### PR TITLE
Fix wrong call to processValue

### DIFF
--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -93,7 +93,7 @@ class JSON2CSVBase {
    */
   getHeader() {
     return fastJoin(
-      this.opts.fields.map(fieldInfo => this.processValue(fieldInfo.label, true)),
+      this.opts.fields.map(fieldInfo => this.processValue(fieldInfo.label)),
       this.opts.delimiter
     );
   }


### PR DESCRIPTION
Minor and irrelevant fix.

The second argument was removed from the function so it's actually never used.