### PR TITLE
Fix the typo in code sample for migrating to 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ const csv = json2csvParser.parse(myData);
 
 should be replaced by
 ```js
-const { Parser, transform: { unwind, flatten } } = require('json2csv');
+const { Parser, transforms: { unwind, flatten } } = require('json2csv');
 const json2csvParser = new Parser({ transforms: [unwind({ paths, blankOut: true }), flatten('__')] });
 const csv = json2csvParser.parse(myData);
 ```


### PR DESCRIPTION
This `const { Parser, transform: { unwind, flatten } } = require('json2csv');` rightfully throws the error `TypeError: Cannot destructure property 'flatten' of 'undefined' or 'null'.`

The correct version should be:
`const { Parser, transforms: { unwind, flatten } } = require('json2csv');`