### PR TITLE
[WIP] Nested arrays should flatten as expected

### DIFF
--- a/test/CLI.js
+++ b/test/CLI.js
@@ -810,6 +810,17 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     });
   });
 
+  testRunner.add('should support flattening JSON with nested arrays using the flatten transform, when arrays a longer in non-0 index entries', (t) => {
+    const opts = '--flatten-objects --flatten-arrays';
+
+    exec(`${cli} -i "${getFixturePath('/json/flattenArraysReversed.json')}" ${opts}`, (err, stdout, stderr) => {
+      t.notOk(stderr);
+      const csv = stdout;
+      t.equal(csv, csvFixtures.flattenedArraysReversed);
+      t.end();
+    });
+  });
+
   testRunner.add('should support custom flatten separator using the flatten transform', (t) => {
     const opts = '--flatten-objects --flatten-separator __';
 

--- a/test/fixtures/csv/flattenedArraysReversed.csv
+++ b/test/fixtures/csv/flattenedArraysReversed.csv
@@ -1,0 +1,3 @@
+"name","age","friends.0.name","friends.0.age","friends.1.name","friends.1.age"
+"Thomas",40,"Harry",35,,
+"Jack",39,"Oliver",40,"Harry",50

--- a/test/fixtures/json/flattenArraysReversed.json
+++ b/test/fixtures/json/flattenArraysReversed.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Thomas",
+    "age": 40,
+    "friends": [{ "name": "Harry", "age": 35 }]
+  },
+  {
+    "name": "Jack",
+    "age": 39,
+    "friends": [{ "name": "Oliver", "age": 40 }, { "name": "Harry", "age": 50 }]
+  }
+]


### PR DESCRIPTION
**Issue**

When flattening an array, it seems that only the length of the first row's nested array is considered. Subsequent rows adhere therefore lose data if they have more items.

**Expected**

The number of flattened array values should equal the longest length of all the available rows.

Includes:
[test] add test for flattened arrays where nested array is longer in subsequent rows