### PR TITLE
Performance optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 node_js:
-  - "10"
   - "11"
   - "12"
   - "13"
+  - "14"
+  - "15"
 script:
   - "npm run lint"
   - "npm run test-with-coverage"

--- a/lib/JSON2CSVAsyncParser.js
+++ b/lib/JSON2CSVAsyncParser.js
@@ -2,7 +2,6 @@
 
 const { Transform } = require('stream');
 const JSON2CSVTransform = require('./JSON2CSVTransform');
-const { fastJoin } = require('./utils');
 
 class JSON2CSVAsyncParser {
   constructor(opts, transformOpts) {
@@ -51,7 +50,7 @@ class JSON2CSVAsyncParser {
       let csvBuffer = [];
       this.processor
         .on('data', chunk => csvBuffer.push(chunk.toString()))
-        .on('finish', () => resolve(fastJoin(csvBuffer, '')))
+        .on('finish', () => resolve(csvBuffer.join('')))
         .on('error', err => reject(err));
     });
   }

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -2,7 +2,7 @@
 
 const os = require('os');
 const lodashGet = require('lodash.get');
-const { getProp, fastJoin, flattenReducer } = require('./utils');
+const { getProp, fastJoin } = require('./utils');
 const defaultFormatter = require('./formatters/default');
 const numberFormatterCtor = require('./formatters/number')
 const stringFormatterCtor = require('./formatters/string');
@@ -123,7 +123,7 @@ class JSON2CSVBase {
    */
   preprocessRow(row) {
     return this.opts.transforms.reduce((rows, transform) =>
-      rows.map(row => transform(row)).reduce(flattenReducer, []),
+      rows.flatMap(row => transform(row)),
       [row]
     );
   }

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -2,7 +2,7 @@
 
 const os = require('os');
 const lodashGet = require('lodash.get');
-const { getProp, fastJoin } = require('./utils');
+const { getProp } = require('./utils');
 const defaultFormatter = require('./formatters/default');
 const numberFormatterCtor = require('./formatters/number')
 const stringFormatterCtor = require('./formatters/string');
@@ -111,10 +111,9 @@ class JSON2CSVBase {
    * @returns {String} titles as a string
    */
   getHeader() {
-    return fastJoin(
-      this.opts.fields.map(fieldInfo => this.opts.formatters.header(fieldInfo.label)),
-      this.opts.delimiter
-    );
+    return this.opts.fields
+      .map(fieldInfo => this.opts.formatters.header(fieldInfo.label))
+      .join(this.opts.delimiter);
   }
 
   /**
@@ -145,10 +144,7 @@ class JSON2CSVBase {
       return undefined;
     }
 
-    return fastJoin(
-      processedRow,
-      this.opts.delimiter
-    );
+    return processedRow.join(this.opts.delimiter);
   }
 
   /**

--- a/lib/JSON2CSVParser.js
+++ b/lib/JSON2CSVParser.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const JSON2CSVBase = require('./JSON2CSVBase');
-const { fastJoin } = require('./utils');
 
 class JSON2CSVParser extends JSON2CSVBase {
   constructor(opts) {
@@ -70,10 +69,10 @@ class JSON2CSVParser extends JSON2CSVBase {
    * @returns {String} CSV string (body)
    */
   processData(data) {
-    return fastJoin(
-      data.map(row => this.processRow(row)).filter(row => row), // Filter empty rows
-      this.opts.eol
-    );
+    return data
+      .map(row => this.processRow(row))
+      .filter(row => row) // Filter empty rows
+      .join(this.opts.eol);
   }
 }
 

--- a/lib/JSON2CSVParser.js
+++ b/lib/JSON2CSVParser.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const JSON2CSVBase = require('./JSON2CSVBase');
-const { fastJoin, flattenReducer } = require('./utils');
+const { fastJoin } = require('./utils');
 
 class JSON2CSVParser extends JSON2CSVBase {
   constructor(opts) {
@@ -60,8 +60,7 @@ class JSON2CSVParser extends JSON2CSVBase {
     if (this.opts.transforms.length === 0) return processedData;
 
     return processedData
-      .map(row => this.preprocessRow(row))
-      .reduce(flattenReducer, []);
+      .flatMap(row => this.preprocessRow(row));
   }
 
   /**

--- a/lib/transforms/unwind.js
+++ b/lib/transforms/unwind.js
@@ -1,6 +1,6 @@
 
 const lodashGet = require('lodash.get');
-const { setProp, flattenReducer } = require('../utils');
+const { setProp } = require('../utils');
 
 function getUnwindablePaths(obj, currentPath) {
   return Object.keys(obj).reduce((unwindablePaths, key) => {
@@ -16,8 +16,7 @@ function getUnwindablePaths(obj, currentPath) {
     } else if (Array.isArray(value)) {
       unwindablePaths.push(newPath);
       unwindablePaths = unwindablePaths.concat(value
-        .map(arrObj => getUnwindablePaths(arrObj, newPath))
-        .reduce(flattenReducer, [])
+        .flatMap(arrObj => getUnwindablePaths(arrObj, newPath))
         .filter((item, index, arr) => arr.indexOf(item) !== index));
     }
 
@@ -34,7 +33,7 @@ function getUnwindablePaths(obj, currentPath) {
 function unwind({ paths = undefined, blankOut = false } = {}) {
   function unwindReducer(rows, unwindPath) {
     return rows
-      .map(row => {
+      .flatMap(row => {
         const unwindArray = lodashGet(row, unwindPath);
 
         if (!Array.isArray(unwindArray)) {
@@ -52,8 +51,7 @@ function unwind({ paths = undefined, blankOut = false } = {}) {
 
           return setProp(clonedRow, unwindPath, unwindRow);
         });
-      })
-      .reduce(flattenReducer, []);
+      });
   }
 
   paths = Array.isArray(paths) ? paths : (paths ? [paths] : undefined);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,17 +11,6 @@ function setProp(obj, path, value) {
   return Object.assign({}, obj, { [key]: newValue });
 }
 
-function flattenReducer(acc, arr) {
-  try {
-    // This is faster but susceptible to `RangeError: Maximum call stack size exceeded`
-    acc.push(...arr);
-    return acc;
-  } catch (err) {
-    // Fallback to a slower but safer option
-    return acc.concat(arr);
-  }
-}
-
 function fastJoin(arr, separator) {
   let isFirst = true;
   return arr.reduce((acc, elem) => {
@@ -37,6 +26,5 @@ function fastJoin(arr, separator) {
 module.exports = {
   getProp,
   setProp,
-  fastJoin,
-  flattenReducer
+  fastJoin
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,20 +11,7 @@ function setProp(obj, path, value) {
   return Object.assign({}, obj, { [key]: newValue });
 }
 
-function fastJoin(arr, separator) {
-  let isFirst = true;
-  return arr.reduce((acc, elem) => {
-    if (isFirst) {
-      isFirst = false;
-      return `${elem}`;
-    }
-
-    return `${acc}${separator}${elem}`;
-  }, '');
-}
-
 module.exports = {
   getProp,
-  setProp,
-  fastJoin
+  setProp
 };


### PR DESCRIPTION
This undoes the performance optimizations that were introduced in #360 and #378.

It seems that v8 has improved significantly: support is a lot better and native implementation of the methods are consistently much faster in all browsers, Node, and Deno.


It can be easily tested using:
```js
function flattenReducer(acc, arr) {
  try {
    // This is faster but susceptible to `RangeError: Maximum call stack size exceeded`
    acc.push(...arr);
    return acc;
  } catch (err) {
    // Fallback to a slower but safer option
    return acc.concat(arr);
  }
}

let start = performance.now();
Array(100).fill(Array(1000).fill(1)).reduce(flattenReducer);
let end = performance.now();
console.log(`Time: ${end - start} ms.`);


start = performance.now();
Array(100).fill(Array(1000).fill(1)).flat();
end = performance.now();
console.log(`Time: ${end - start} ms.`);
```

```js
function fastJoin(arr, separator) {
  let isFirst = true;
  return arr.reduce((acc, elem) => {
    if (elem === null || elem === undefined) {
      elem = '';
    }

    if (isFirst) {
      isFirst = false;
      return `${elem}`;
    }

    return `${acc}${separator}${elem}`;
  }, '');
}

let size = 1000
let start = performance.now();
fastJoin(Array(size).fill('test'), '-');
let end = performance.now();
console.log(`Time: ${end - start} ms.`);


start = performance.now();
Array(size).fill('test').join('-');
end = performance.now();
console.log(`Time: ${end - start} ms.`);
```

for Node, you need to import performance  doing `const { performance } = require('perf_hooks');`
