### PR TITLE
fix: issue with string array

### DIFF
--- a/lib/formatters/object.js
+++ b/lib/formatters/object.js
@@ -10,6 +10,11 @@ function objectFormatter(opts = { stringFormatter: defaulStringFormatter() }) {
 
     if (value[0] === '"') value = value.replace(/^"(.+)"$/,'$1');
 
+    // Formatter for array
+    if (value.startsWith('[') && value.endsWith(']')) {
+      value = value.replace(/","/g,"','").replace(/^\["/,"['").replace(/"\]$/,"']");
+    }
+
     return opts.stringFormatter(value);
   }
 }

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -846,4 +846,13 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       t.end();
     });
   });
+
+  testRunner.add('should output array correctly', (t) => {
+    exec(`${cli} -i "${getFixturePath('/json/array.json')}"`, (err, stdout, stderr) => {
+      t.notOk(stderr); 
+      const csv = stdout;
+      t.equal(csv, csvFixtures.array);
+      t.end();
+    });
+  });
 };

--- a/test/JSON2CSVAsyncParser.js
+++ b/test/JSON2CSVAsyncParser.js
@@ -1299,4 +1299,16 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
 
     t.end();
   });
+
+  testRunner.add('should output array correctly', async (t) => {
+    const parser = new AsyncParser();
+    try {
+      const csv = await parser.parse(jsonFixtures.array()).promise();
+      t.equal(csv, csvFixtures.array);
+    } catch(err) {
+      t.fail(err.message);
+    }
+
+    t.end();
+  });
 };

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -947,4 +947,12 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.equal(csv, csvFixtures.customHeaderQuotes);
     t.end();
   });
+
+  testRunner.add('should output array correctly', (t) => {
+    const parser = new Json2csvParser();
+    const csv = parser.parse(jsonFixtures.array);
+
+    t.equal(csv, csvFixtures.array);
+    t.end();
+  });
 };

--- a/test/JSON2CSVTransform.js
+++ b/test/JSON2CSVTransform.js
@@ -1508,4 +1508,22 @@ module.exports = (testRunner, jsonFixtures, csvFixtures, inMemoryJsonFixtures) =
         t.end();  
       });
   });
+
+
+  testRunner.add('should output array correctly', (t) => {
+    const transform = new Json2csvTransform();
+    const processor = jsonFixtures.array().pipe(transform);
+
+    let csv = '';
+    processor
+      .on('data', chunk => (csv += chunk.toString()))
+      .on('end', () => {
+        t.equal(csv, csvFixtures.array);
+        t.end();
+      })
+      .on('error', err => {
+        t.fail(err.message);
+        t.end();  
+      });
+  });
 };

--- a/test/fixtures/csv/array.csv
+++ b/test/fixtures/csv/array.csv
@@ -1,0 +1,3 @@
+"categories"
+"['apple','orange']"
+"['apple']"

--- a/test/fixtures/json/array.json
+++ b/test/fixtures/json/array.json
@@ -1,0 +1,4 @@
+[
+  {"categories": ["apple", "orange"]},
+  {"categories": ["apple"]}
+]


### PR DESCRIPTION
Currently, if you got an string array, the csv output is like this: 

`"[""apple"",""orange""]"`

which will raise error when trying to import to databases (in my case: clickhouse). The output should be 

`"['apple','orange']"`


Reminder: 

I only tested importing csv to Clickhouse. I didn't test other databases.