### PR TITLE
return defaultValue for null and undefined

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,8 @@
 'use strict';
 
 function getProp(obj, path, defaultValue) {
-  return obj[path] === undefined ? defaultValue : obj[path];
+  const value = obj[path];
+  return (value === null || value === undefined) ? defaultValue : value;
 }
 
 function setProp(obj, path, value) {


### PR DESCRIPTION
- treat null and undefined as missing
- apply same behaviour as in https://github.com/zemirco/json2csv/blob/2ea1c3c3c1259725a8b43458ef788ef30ef6d0a8/lib/JSON2CSVBase.js#L94-L106

Current behaviour:
```
const fields = [{ label: 'ID', value: 'id' }];
const transformer = new Transform({ fields });
```
Converts only `undefined` to `defaultValue` (see getProp)

```
const fields = [{ label: 'ID', value: (row) => row['id'] }];
const transformer = new Transform({ fields });
```
Converts `null` and `undefined` to `defaultValue` (see [here](https://github.com/zemirco/json2csv/blob/2ea1c3c3c1259725a8b43458ef788ef30ef6d0a8/lib/JSON2CSVBase.js#L94-L106))