### PR TITLE
New option to format numbers using locale settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Options:
   -a, --include-empty-rows            Includes empty rows in the resulting CSV output.
   -b, --with-bom                      Includes BOM character at the beginning of the CSV.
   -p, --pretty                        Print output as a pretty table. Use only when printing to console.
+  -l, --locale                        Locale to use for numbers formatting, Defaults to no locale formatting.
   --unwind [paths]                    Creates multiple rows from a single JSON document similar to MongoDB unwind.
   --unwind-blank                      When unwinding, blank out instead of repeating data. Defaults to false. (default: false)
   --flatten-objects                   Flatten nested objects. Defaults to false. (default: false)
@@ -183,6 +184,7 @@ The programatic APIs take a configuration object very equivalent to the CLI opti
 - `header` - Boolean, determines whether or not CSV file will contain a title column. Defaults to `true` if not specified.
 - `includeEmptyRows` - Boolean, includes empty rows. Defaults to `false`.
 - `withBOM` - Boolean, with BOM character. Defaults to `false`.
+- `locale` - String, locale to use for numbers formatting, Defaults to no locale formatting. 
 
 ### json2csv parser (Synchronous API)
 

--- a/bin/json2csv.js
+++ b/bin/json2csv.js
@@ -37,6 +37,7 @@ program
   .option('-a, --include-empty-rows', 'Includes empty rows in the resulting CSV output.')
   .option('-b, --with-bom', 'Includes BOM character at the beginning of the CSV.')
   .option('-p, --pretty', 'Print output as a pretty table. Use only when printing to console.')
+  .option('-l, --locale <locale>', 'Locale to use for numbers formatting, Defaults to no locale formatting.')
   // Built-in transforms
   .option('--unwind [paths]', 'Creates multiple rows from a single JSON document similar to MongoDB unwind.')
   .option('--unwind-blank', 'When unwinding, blank out instead of repeating data. Defaults to false.', false)
@@ -163,7 +164,8 @@ async function processStream(config, opts) {
       excelStrings: config.excelStrings,
       header: config.header,
       includeEmptyRows: config.includeEmptyRows,
-      withBOM: config.withBom
+      withBOM: config.withBom,
+      locale: config.locale
     };
 
     await (config.streaming ? processStream : processInMemory)(config, opts);

--- a/lib/JSON2CSVBase.js
+++ b/lib/JSON2CSVBase.js
@@ -179,6 +179,10 @@ class JSON2CSVBase {
         }
         value = `${this.opts.quote}${value}${this.opts.quote}`;
       }
+    } else if (typeof value === 'number') {
+      if (this.opts.locale) {
+        value = value.toLocaleString(this.opts.locale);
+      }
     }
 
     return value;

--- a/test/CLI.js
+++ b/test/CLI.js
@@ -853,4 +853,15 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
       t.end();
     });
   });
+
+  testRunner.add('should format number to locale settings', (t) => {
+    const opts = '--fields carModel,price,color,transmission --delimiter ";" --locale it';
+
+    exec(`${cli} -i "${getFixturePath('/json/numberLocaleFormatting.json')}" ${opts}`, (err, stdout, stderr) => {
+      t.notOk(stderr);
+      const csv = stdout;
+      t.equal(csv, csvFixtures.numberLocaleFormatting);
+      t.end();
+    });
+  });
 };

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -835,4 +835,18 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.equal(csv, csvFixtures.defaultCustomTransform);
     t.end();
   });
+
+  testRunner.add('should format number to locale settings', (t) => {
+    const opts = {
+      delimiter: ";",
+      locale: "it"
+    };
+
+    const parser = new Json2csvParser(opts);
+    const csv = parser.parse(jsonFixtures.numberLocaleFormatting);
+
+    t.equal(csv, csvFixtures.numberLocaleFormatting);
+    t.end();
+  });
+
 };

--- a/test/fixtures/csv/numberLocaleFormatting.csv
+++ b/test/fixtures/csv/numberLocaleFormatting.csv
@@ -1,0 +1,5 @@
+"carModel";"price";"color";"transmission"
+"Audi";0;"blue";
+"BMW";15.000;"red";"manual"
+"Mercedes";20.000,12;"yellow";
+"Porsche";30.000;"green";

--- a/test/fixtures/json/numberLocaleFormatting.json
+++ b/test/fixtures/json/numberLocaleFormatting.json
@@ -1,0 +1,6 @@
+[
+  { "carModel": "Audi",      "price": 0,  "color": "blue" },
+  { "carModel": "BMW",       "price": 15000.00,  "color": "red", "transmission": "manual" },
+  { "carModel": "Mercedes",  "price": 20000.12,  "color": "yellow" },
+  { "carModel": "Porsche",   "price": 30000,  "color": "green" }
+]


### PR DESCRIPTION
With this option we can open a csv file with Excel and directly do calculation on numeric fields, without this option Excel on windows with Italy locales interprets the numeric fields like 1200.00 as string.