### PR TITLE
Fix typo in eol option for stringQuoteOnlyIfNecessary

### DIFF
--- a/lib/formatters/stringQuoteOnlyIfNecessary.js
+++ b/lib/formatters/stringQuoteOnlyIfNecessary.js
@@ -5,7 +5,7 @@ function stringQuoteOnlyIfNecessaryFormatter(opts = {}) {
   const quote = typeof opts.quote === 'string' ? opts.quote  : '"';
   const escapedQuote = typeof opts.escapedQuote === 'string' ? opts.escapedQuote : `${quote}${quote}`;
   const separator = typeof opts.separator === 'string' ? opts.separator : ',';
-  const eol = typeof opts.eol === 'string' ? opts.escapedQeoluote : os.EOL;
+  const eol = typeof opts.eol === 'string' ? opts.eol : os.EOL;
 
   const stringFormatter = defaulStringFormatter({ quote, escapedQuote });
 

--- a/test/JSON2CSVParser.js
+++ b/test/JSON2CSVParser.js
@@ -757,6 +757,21 @@ module.exports = (testRunner, jsonFixtures, csvFixtures) => {
     t.equal(csv, csvFixtures.quoteOnlyIfNecessary);
   });
 
+  testRunner.add('should respect the stringQuoteOnlyIfNecessary eol option', async (t) => {
+    const opts = {
+      formatters: {
+        string: stringQuoteOnlyIfNecessaryFormatter({ eol: '\r\n' })
+      },
+      eol: '\r\n'
+    };
+
+    const parser = new Parser(opts);
+    const csv = await parseInput(parser, jsonFixtures.quoteOnlyIfNecessaryCRLF());
+
+    // Git will not store the CRLF newlines in the fixture, so simulate them here.
+    t.equal(csv, csvFixtures.quoteOnlyIfNecessaryCRLF.replace(/\n/g, '\r\n'));
+  });
+
   // String Excel
 
   testRunner.add('should format strings to force excel to view the values as strings', async (t) => {

--- a/test/fixtures/csv/quoteOnlyIfNecessaryCRLF.csv
+++ b/test/fixtures/csv/quoteOnlyIfNecessaryCRLF.csv
@@ -1,0 +1,3 @@
+a string
+"with a CRLF
+newline"

--- a/test/fixtures/json/quoteOnlyIfNecessaryCRLF.json
+++ b/test/fixtures/json/quoteOnlyIfNecessaryCRLF.json
@@ -1,0 +1,3 @@
+[
+  {"a string": "with a CRLF\r\nnewline"}
+]


### PR DESCRIPTION
It looks like there is a typo in the check for `opts.eol` in the `stringQuoteOnlyIfNecessary` formatter. This fixes the typo and adds a test.

(There may be a better way to test this... I could not commit a fixture CSV file with CRLF newlines.)